### PR TITLE
Monkey patch to leverage DNS roundrobin

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <type id="django" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" default="false" project-jdk-name="Python 3.5.2 virtualenv at ~/src/c2cwsgiutils/.venv" project-jdk-type="Python SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" default="false" project-jdk-name="Python 3.6 virtualenv at ~/src/c2c/c2cwsgiutils/.venv" project-jdk-type="Python SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/c2cwsgiutils/_patches.py
+++ b/c2cwsgiutils/_patches.py
@@ -1,0 +1,71 @@
+"""
+Monkey patch standard functions to improve their behavior
+"""
+
+import ipaddress
+import random
+import socket
+from typing import Tuple, List, Any, Callable
+
+_orig_socket_getaddrinfo = socket.getaddrinfo
+_orig_socket_gethostbyname_ex = socket.gethostbyname_ex
+
+
+def randomized_socket_getaddrinfo(
+        *args: Any, **kwargs: Any) -> List[Tuple[int, int, int, str, Tuple[Any, ...]]]:
+    """
+    socket.getaddrinfo is not DNS roundrobin friendly. This randomizes it.
+    """
+    result = _orig_socket_getaddrinfo(*args, **kwargs)
+    return _shuffle_addresses(result, lambda entry: entry[4][0])
+
+
+def randomized_socket_gethostbyname_ex(hostname: str) -> Tuple[str, List[str], List[str]]:  # pragma: no cover
+    """
+    socket.gethostbyname_ex is not DNS roundrobin friendly. This randomizes it.
+    """
+    hostname, aliaslist, ipaddrlist = _orig_socket_gethostbyname_ex(hostname)
+    ipaddrlist = _shuffle_addresses(ipaddrlist, lambda entry: entry)
+    return hostname, aliaslist, ipaddrlist
+
+
+def randomized_socket_gethostbyname(hostname: str) -> str:  # pragma: no cover
+    """
+    socket.gethostbyname is not DNS roundrobin friendly. This randomizes it.
+    """
+    result = _orig_socket_gethostbyname_ex(hostname)
+    return random.choice(result[2])
+
+
+def init() -> None:
+    socket.getaddrinfo = randomized_socket_getaddrinfo
+    socket.gethostbyname_ex = randomized_socket_gethostbyname_ex
+    socket.gethostbyname = randomized_socket_gethostbyname
+
+
+def _shuffle_addresses(entries: list, get_address: Callable[[Any], str]) -> list:
+    """
+    Randomizes the given addresses, but keep the order between address types. For example, if the IPv4
+    addresses were first, they will stay first
+    """
+    if len(entries) <= 1:
+        return entries
+    v4 = []
+    v6 = []
+    what_first = None
+    for entry in entries:
+        addr = get_address(entry)
+        version = ipaddress.ip_address(addr).version
+        if version == 4:
+            v4.append(entry)
+        else:
+            v6.append(entry)
+        if what_first is None:
+            what_first = version
+
+    if len(v4) > 1:
+        random.shuffle(v4)
+    if len(v6) > 1:
+        random.shuffle(v6)
+
+    return v4 + v6 if what_first == 4 else v6 + v4

--- a/c2cwsgiutils/wsgi_app.py
+++ b/c2cwsgiutils/wsgi_app.py
@@ -1,14 +1,20 @@
 """
 Module used by c2cwsgiutils_run.sh to provide a WSGI application when starting gunicorn
 """
-from typing import Callable
+from typing import Callable  # pragma: no cover
 from c2cwsgiutils import coverage_setup  # pragma: no cover
 coverage_setup.init()  # pragma: no cover
 
 
-def create() -> Callable:  # pragma: no cover
+def _create() -> Callable:  # pragma: no cover
     from c2cwsgiutils import wsgi, sentry
     return sentry.filter_wsgi_app(wsgi.create_application())
+
+
+def create() -> Callable:  # pragma: no cover
+    from c2cwsgiutils import _patches
+    _patches.init()  # pragma: no cover
+    return _create()
 
 
 application = create()  # pragma: no cover

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,0 +1,44 @@
+from c2cwsgiutils import _patches
+import socket
+
+
+def test_shuffle_addresses():
+    shuffle = _patches._shuffle_addresses  # pylint: disable=W0212
+
+    # check we keep v6/v4 ordering
+    for _ in range(10):
+        assert shuffle(['1.2.3.4', '1:2:3::4'], lambda x: x) == ['1.2.3.4', '1:2:3::4']
+        assert shuffle(['1:2:3::4', '1.2.3.4'], lambda x: x) == ['1:2:3::4', '1.2.3.4']
+
+    assert shuffle(['1.2.3.4'], lambda x: x) == ['1.2.3.4']
+    assert shuffle(['1:2:3::4'], lambda x: x) == ['1:2:3::4']
+
+    assert set(shuffle(['1.2.3.4', '1.2.3.5', '1.2.3.6'], lambda x: x)) == {'1.2.3.4', '1.2.3.5', '1.2.3.6'}
+
+    not_shuffled = True
+    orig = ['1.2.3.4', '1.2.3.5', '1.2.3.6']
+    for _ in range(50):
+        not_shuffled = not_shuffled and shuffle(orig, lambda x: x) == orig
+    assert not not_shuffled
+
+
+def test_randomized_socket_getaddrinfo():
+    result = _patches.randomized_socket_getaddrinfo('www.thus.ch', 80, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    assert len(result) >= 1
+    for _family, type_, proto, _canonname, sockaddr in result:
+        assert type_ == socket.SOCK_STREAM
+        assert proto == socket.SOL_TCP
+        assert sockaddr[1] == 80
+
+
+def test_randomized_socket_gethostbyname_ex():
+    hostname, aliaslist, ipaddrlist = _patches.randomized_socket_gethostbyname_ex('www.thus.ch')
+    assert isinstance(hostname, str)
+    assert isinstance(aliaslist, list)
+    assert isinstance(ipaddrlist, list)
+    assert len(ipaddrlist) >= 1
+
+
+def test_randomized_socket_gethostbyname():
+    ipaddr = _patches.randomized_socket_gethostbyname('www.thus.ch')
+    assert isinstance(ipaddr, str)


### PR DESCRIPTION
Libraries like requests don't leverage DNS roundrobin because
`socket.getaddrinfo` is not randomizing properly the list of returned IP
addresses. This installs monkey patches fixing that.