### PR TITLE
Restore old flake8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cee_syslog_handler==0.4.1
 codacy-coverage==1.3.7
 cornice==3.0.0
 coverage==4.4.1
-flake8==3.4.1
+flake8==3.4.1  # rq.filter: <3.5.0
 gunicorn==19.7.1
 junit2html==007  # rq.filter: !=009, !=008
 lxml==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cee_syslog_handler==0.4.1
 codacy-coverage==1.3.7
 cornice==3.0.0
 coverage==4.4.1
-flake8==3.5.0
+flake8==3.4.1
 gunicorn==19.7.1
 junit2html==007  # rq.filter: !=009, !=008
 lxml==4.1.0


### PR DESCRIPTION
The new flake8 is breaking all our original images.
The flake8 update should be part of a new tag.