### PR TITLE
Use psycopg2-binary instead of psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lxml==4.1.1
 mypy==0.560
 netifaces==0.10.6
 objgraph==3.4.0
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 pyparsing==2.2.0
 pyramid==1.9.1
 pyramid_tm==2.2


### PR DESCRIPTION
To remove the following warning:
UserWarning: The psycopg2 wheel package will be renamed from release 2.8;
in order to keep installing from binary please use "pip install psycopg2-binary" instead.
For details see:
<http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.