### PR TITLE
Stop using pyparsing for simplifing SQL expression

### DIFF
--- a/tests/test_stats_pyramid.py
+++ b/tests/test_stats_pyramid.py
@@ -14,3 +14,6 @@ def test_simplify_sql():
 
     assert simplify_sql("SELECT a FROM xxx WHERE b IN (1, 2) AND c IN ((d, 1), (e, 2))") == \
         "SELECT FROM xxx WHERE b IN (?) AND c IN (?)"
+
+    assert simplify_sql("SELECT a FROM xxx WHERE b IN (1, ')', 2)") == \
+        "SELECT FROM xxx WHERE b IN (?)"


### PR DESCRIPTION
For some actual queries, we where spending 15% of the CPU just
simplifying the IN clauses in the SQL queries. The new implementation is
now manually parsing the string to find the end of the expression.