### PR TITLE
Add a fast_json renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,17 @@ c2c.disable_exception_handling = 1
 
 # JSON pretty print
 
-The standard JSON renderer is replaced by a version that pretty prints the rendered JSON. While this adds
-significant amount of whitespace, the difference in bytes transmitted on the network is negligible thanks
-to gzip compression.
+Two JSON renderers are available:
+
+* `json`: the normal JSON renderer (default)
+* `fast_json`: a faster JSON renderer
+is tuned differently.
+
+Both pretty prints the rendered JSON. While this adds significant amount of whitespace, the difference in
+bytes transmitted on the network is negligible thanks to gzip compression.
+
+The `fast_json` renderer is using ujson which is faster, but doesn't offer the ability to change the rendering
+of some types (the `default` parameter of json.dumps). This will interact badly with `papyrus` and such.
 
 
 ## Sentry integration

--- a/acceptance_tests/app/c2cwsgiutils_app/services.py
+++ b/acceptance_tests/app/c2cwsgiutils_app/services.py
@@ -9,7 +9,7 @@ from c2cwsgiutils_app import models
 
 
 ping_service = services.create("ping", "/ping")
-hello_service = services.create("hello", "/hello", cors_credentials=True)
+hello_service = services.create("hello", "/hello", cors_credentials=True, renderer='fast_json')
 error_service = services.create("error", "/error")
 tracking_service = services.create("tracking", "/tracking/{depth:[01]}")
 empty_service = services.create("empty", "/empty")

--- a/c2cwsgiutils/debug.py
+++ b/c2cwsgiutils/debug.py
@@ -112,22 +112,23 @@ def init(config: pyramid.config.Configurator) -> None:
 
         config.add_route("c2c_debug_stacks", _utils.get_base_path(config) + r"/debug/stacks",
                          request_method="GET")
-        config.add_view(_dump_stacks, route_name="c2c_debug_stacks", renderer="json", http_cache=0)
+        config.add_view(_dump_stacks, route_name="c2c_debug_stacks", renderer="fast_json", http_cache=0)
 
         config.add_route("c2c_debug_memory", _utils.get_base_path(config) + r"/debug/memory",
                          request_method="GET")
-        config.add_view(_dump_memory, route_name="c2c_debug_memory", renderer="json", http_cache=0)
+        config.add_view(_dump_memory, route_name="c2c_debug_memory", renderer="fast_json", http_cache=0)
 
         config.add_route("c2c_debug_memory_diff", _utils.get_base_path(config) + r"/debug/memory_diff/*path",
                          request_method="GET")
-        config.add_view(_dump_memory_diff, route_name="c2c_debug_memory_diff", renderer="json", http_cache=0)
+        config.add_view(_dump_memory_diff, route_name="c2c_debug_memory_diff", renderer="fast_json",
+                        http_cache=0)
 
         config.add_route("c2c_debug_sleep", _utils.get_base_path(config) + r"/debug/sleep",
                          request_method="GET")
-        config.add_view(_sleep, route_name="c2c_debug_sleep", renderer="json", http_cache=0)
+        config.add_view(_sleep, route_name="c2c_debug_sleep", renderer="fast_json", http_cache=0)
 
         config.add_route("c2c_debug_headers", _utils.get_base_path(config) + r"/debug/headers",
                          request_method="GET")
-        config.add_view(_headers, route_name="c2c_debug_headers", renderer="json", http_cache=0)
+        config.add_view(_headers, route_name="c2c_debug_headers", renderer="fast_json", http_cache=0)
 
         LOG.info("Enabled the /debug/stacks API")

--- a/c2cwsgiutils/health_check.py
+++ b/c2cwsgiutils/health_check.py
@@ -51,7 +51,7 @@ class HealthCheck(object):
     def __init__(self, config: pyramid.config.Configurator) -> None:
         config.add_route("c2c_health_check", _utils.get_base_path(config) + r"/health_check",
                          request_method="GET")
-        config.add_view(self._view, route_name="c2c_health_check", renderer="json", http_cache=0)
+        config.add_view(self._view, route_name="c2c_health_check", renderer="fast_json", http_cache=0)
         self._checks = []  # type: List[Tuple[str, Callable[[pyramid.request.Request], Any], int]]
 
     def add_db_session_check(self, session: sqlalchemy.orm.Session,

--- a/c2cwsgiutils/logging_view.py
+++ b/c2cwsgiutils/logging_view.py
@@ -19,7 +19,8 @@ def install_subscriber(config: pyramid.config.Configurator) -> None:
 
         config.add_route("c2c_logging_level", _utils.get_base_path(config) + r"/logging/level",
                          request_method="GET")
-        config.add_view(_logging_change_level, route_name="c2c_logging_level", renderer="json", http_cache=0)
+        config.add_view(_logging_change_level, route_name="c2c_logging_level", renderer="fast_json",
+                        http_cache=0)
         LOG.info("Enabled the /logging/change_level API")
 
 

--- a/c2cwsgiutils/pretty_json.py
+++ b/c2cwsgiutils/pretty_json.py
@@ -1,6 +1,13 @@
 import pyramid.config
 from pyramid.renderers import JSON
+from typing import Any
+import ujson
+
+
+def fast_dumps(v: Any, **_kargv: Any) -> str:
+    return ujson.dumps(v, ensure_ascii=False, indent=2, sort_keys=True)
 
 
 def init(config: pyramid.config.Configurator) -> None:
-    config.add_renderer('json', JSON(indent=4, sort_keys=True))
+    config.add_renderer('json', JSON(indent=2, sort_keys=True))
+    config.add_renderer('fast_json', JSON(serializer=fast_dumps))

--- a/c2cwsgiutils/sql_profiler.py
+++ b/c2cwsgiutils/sql_profiler.py
@@ -91,5 +91,5 @@ def init(config: pyramid.config.Configurator) -> None:
 
         config.add_route("c2c_sql_profiler", _utils.get_base_path(config) + r"/sql_profiler",
                          request_method="GET")
-        config.add_view(_sql_profiler_view, route_name="c2c_sql_profiler", renderer="json", http_cache=0)
+        config.add_view(_sql_profiler_view, route_name="c2c_sql_profiler", renderer="fast_json", http_cache=0)
         LOG.info("Enabled the /sql_profiler API")

--- a/c2cwsgiutils/stats_pyramid.py
+++ b/c2cwsgiutils/stats_pyramid.py
@@ -166,6 +166,6 @@ def init(config: pyramid.config.Configurator) -> None:
                              request_method="GET")
             memory_backend = cast(stats.MemoryBackend, stats.BACKENDS['memory'])
             config.add_view(memory_backend.get_stats, route_name="c2c_read_stats_json",
-                            renderer="json", http_cache=0)
+                            renderer="fast_json", http_cache=0)
         init_pyramid_spy(config)
         init_db_spy()

--- a/c2cwsgiutils/version.py
+++ b/c2cwsgiutils/version.py
@@ -15,7 +15,8 @@ def init(config: pyramid.config.Configurator) -> None:
             versions = json.load(file)
         config.add_route("c2c_versions", _utils.get_base_path(config) + r"/versions.json",
                          request_method="GET")
-        config.add_view(lambda request: versions, route_name="c2c_versions", renderer="json", http_cache=0)
+        config.add_view(lambda request: versions, route_name="c2c_versions", renderer="fast_json",
+                        http_cache=0)
         LOG.info("Installed the /versions.json service")
         if 'git_tag' in versions['main']:
             LOG.warning("Starting version %s (%s)", versions['main']['git_tag'], versions['main']['git_hash'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,6 @@ pytest-cov==2.5.1
 raven==6.6.0
 requests==2.18.4
 SQLAlchemy==1.2.5
+ujson==1.35
 zope.interface==4.4.3
 zope.sqlalchemy==1.0


### PR DESCRIPTION
For requests returning a lot of JSON data, the rendering phase takes up to
50% of the time. Using a renderer that goes up to 3 times faster can make a
lot of difference.

Not using this renderer by default, because it interacts badly with papyrus.