### PR TITLE
Tune error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ application views and will transform it into a JSON response with a HTTP status 
 
 You can disable this by setting `C2C_DISABLE_EXCEPTION_HANDLING` (`c2c.disable_exception_handling`) to "1".
 
+In development mode (`DEVELOPMENT=1`), all the details (SQL statement, stacktrace, ...) are sent to the
+client. In production mode, you can still get them by sending the secret defined in `ERROR_DETAILS_SECRET`
+(`c2c.error_details_secret`) in the query.
+
 If you want to use pyramid_debugtoolbar, you need to disable exception handling and configure it like that:
 ```
 pyramid.includes =

--- a/c2cwsgiutils/_auth.py
+++ b/c2cwsgiutils/_auth.py
@@ -5,9 +5,13 @@ import pyramid.request
 from c2cwsgiutils._utils import env_or_settings
 
 
-def auth_view(request: pyramid.request.Request, env_name: str, config_name: str) -> None:
+def is_auth(request: pyramid.request.Request, env_name: str, config_name: str) -> bool:
     secret = request.params.get('secret')
     if secret is None:
         secret = request.headers.get('X-API-Key')
-    if secret != env_or_settings(request.registry.settings, env_name, config_name, False):
+    return secret == env_or_settings(request.registry.settings, env_name, config_name, False)
+
+
+def auth_view(request: pyramid.request.Request, env_name: str, config_name: str) -> None:
+    if not is_auth(request, env_name, config_name):
         raise HTTPForbidden('Missing or invalid secret (parameter or X-API-Key header)')


### PR DESCRIPTION
* Fix bug in detecting development mode.
* Less information disclosure in the message sent to the client.
* Stop putting the exception message twice in the logs.
* If the client provides the secret, the full info is sent.