### PR TITLE
Make WSGI startup tougher

### DIFF
--- a/c2cwsgiutils/profiler.py
+++ b/c2cwsgiutils/profiler.py
@@ -10,11 +10,15 @@ _MODULES = os.environ.get("C2C_PROFILER_MODULES", "")
 
 def filter_wsgi_app(application: Callable) -> Callable:
     if _PATH != "":
-        import linesman.middleware
-        LOG.info("Enable WSGI filter for the profiler on %s", _PATH)
-        linesman.middleware.ENABLED_FLAG_FILE = os.path.join(gettempdir(), 'linesman-enabled')
-        return linesman.middleware.ProfilingMiddleware(
-            app=application, profiler_path=_PATH, chart_packages=_MODULES,
-            filename=os.path.join(gettempdir(), 'linesman-graph-sessions.db'))
+        try:
+            import linesman.middleware
+            LOG.info("Enable WSGI filter for the profiler on %s", _PATH)
+            linesman.middleware.ENABLED_FLAG_FILE = os.path.join(gettempdir(), 'linesman-enabled')
+            return linesman.middleware.ProfilingMiddleware(
+                app=application, profiler_path=_PATH, chart_packages=_MODULES,
+                filename=os.path.join(gettempdir(), 'linesman-graph-sessions.db'))
+        except Exception:
+            LOG.error("Failed enabling the profiler. Continuing without it.", exc_info=True)
+            return application
     else:
         return application

--- a/c2cwsgiutils/sentry.py
+++ b/c2cwsgiutils/sentry.py
@@ -63,7 +63,11 @@ def filter_wsgi_app(application: Callable) -> Callable:
     """
     global client
     if client is not None:
-        LOG.info("Enable WSGI filter for Sentry")
-        return middleware.Sentry(application, client)
+        try:
+            LOG.info("Enable WSGI filter for Sentry")
+            return middleware.Sentry(application, client)
+        except Exception:
+            LOG.error("Failed enabling sentry. Continuing without it.", exc_info=True)
+            return application
     else:
         return application

--- a/c2cwsgiutils/wsgi_app.py
+++ b/c2cwsgiutils/wsgi_app.py
@@ -7,8 +7,14 @@ coverage_setup.init()  # pragma: no cover
 
 
 def create() -> Callable:  # pragma: no cover
-    from c2cwsgiutils import wsgi, sentry, profiler
-    return sentry.filter_wsgi_app(profiler.filter_wsgi_app(wsgi.create_application()))
+    # first import and initialize the wsgi application in order to have the logs setup before importing
+    # anything else
+    from c2cwsgiutils import wsgi
+    main_app = wsgi.create_application()
+
+    # then, we can setup a few filters
+    from c2cwsgiutils import sentry, profiler
+    return sentry.filter_wsgi_app(profiler.filter_wsgi_app(main_app))
 
 
 application = create()  # pragma: no cover


### PR DESCRIPTION
If the optional, non business critical services cannot be setup, we now
log an error and just continue without it. Before, WSGI was just
silently failing to start in an infinite loop.

Closes #150