### PR TITLE
Fix broadcast.decorate

### DIFF
--- a/c2cwsgiutils/broadcast/__init__.py
+++ b/c2cwsgiutils/broadcast/__init__.py
@@ -84,7 +84,7 @@ def decorator(channel: Optional[str]=None, expect_answers: bool=False, timeout: 
             return broadcast(_channel, params=kwargs, expect_answers=expect_answers, timeout=timeout)
 
         if channel is None:
-            _channel = 'c2c_decorated_' + str(id(func))
+            _channel = 'c2c_decorated_%s.%s' % (func.__module__, func.__name__)
         else:
             _channel = channel
         subscribe(_channel, func)


### PR DESCRIPTION
The `id()` function is different in all the processes. Now use the
function module and name as ID.