### PR TITLE
Test index behind a proxy doing https

### DIFF
--- a/acceptance_tests/app/production.ini
+++ b/acceptance_tests/app/production.ini
@@ -25,6 +25,12 @@ sqlalchemy_slave.max_overflow = 25
 c2c.base_path = /c2c
 c2c.sql_request_id = True
 
+filter-with = proxy-prefix
+
+[filter:proxy-prefix]
+# Needed to take into account X-Forwarded-* headers
+use = egg:PasteDeploy#prefix
+
 ###
 # logging configuration
 # http://docs.pylonsproject.org/projects/pyramid/en/1.6-branch/narr/logging.html

--- a/acceptance_tests/tests/tests/test_index.py
+++ b/acceptance_tests/tests/tests/test_index.py
@@ -1,3 +1,6 @@
+from c2cwsgiutils.acceptance import utils
+
+
 def test_without_secret(app_connection):
     content = app_connection.get('c2c')
     assert "Health checks" in content
@@ -8,3 +11,10 @@ def test_with_secret(app_connection):
     content = app_connection.get('c2c', params={'secret': 'changeme'})
     assert "Health checks" in content
     assert "Debug" in content
+
+
+def test_https(app_connection):
+    content = app_connection.get('c2c', params={'secret': 'changeme'},
+                                 headers={'X-Forwarded-Proto': 'https'})
+    assert 'https://' + utils.DOCKER_GATEWAY + ':8480/api/' in content
+    assert 'http://' + utils.DOCKER_GATEWAY + ':8480/api/' not in content


### PR DESCRIPTION
Without the `PasteDeploy#prefix` filter the URLs returned by `route_url`
didn't have the https protocol when behind a proxy doing https. The
`X-Forwarded-Proto` was not taken into account.

This modification is only for showing how the applications using c2cwsgiutils
should be configured.