### PR TITLE
Install screen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
         git \
         graphviz-dev \
         graphviz \
+        screen \
         vim && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/*

--- a/Dockerfile.3.5
+++ b/Dockerfile.3.5
@@ -10,6 +10,7 @@ RUN apt-get update && \
         postgresql-client-9.6 \
         graphviz-dev \
         graphviz \
+        screen \
         vim && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
Screen is useful to start long-lasting tasks in a safer way.

Since the container is often run as a non-root user it is important to have it as part of the base image.