### PR TITLE
Store logging levels in redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Look at the logging configuration part of
 You can enable a view to configure the logging level on a live system using the `C2C_LOG_VIEW_ENABLED` environment
 variable. Then, the current status of a logger can be queried with a GET on
 `{C2C_BASE_PATH}/logging/level?secret={C2C_SECRET}&name={logger_name}` and can be changed with
-`{C2C_BASE_PATH}/logging/level?secret={C2C_SECRET}&name={logger_name}&level={level}`
+`{C2C_BASE_PATH}/logging/level?secret={C2C_SECRET}&name={logger_name}&level={level}`. Overrides are stored in
+Redis, if `C2C_REDIS_URL` (`c2c.redis_url`) is configured.
 
 
 ### Request tracking

--- a/acceptance_tests/tests/tests/test_logging.py
+++ b/acceptance_tests/tests/tests/test_logging.py
@@ -14,7 +14,9 @@ def _query(app_connection, params, expected=None):
     all_params.update(params)
     response = app_connection.get_json('c2c/logging/level', params=all_params)
 
-    all_expected = {'status': 200, 'name': all_params['name']}
+    all_expected = {'status': 200}
+    if 'name' in all_params:
+        all_expected['name'] = all_params['name']
     all_expected.update(expected)
     assert response == all_expected
 
@@ -31,6 +33,8 @@ def test_api(app_connection):
 
     _query(app_connection, {'name': 'sqlalchemy.engine', 'level': 'DEBUG'},
            {'level': 'DEBUG', 'effective_level': 'DEBUG'})
+
+    _query(app_connection, {}, {'overrides': {'sqlalchemy.engine': 'DEBUG'}})
 
 
 def test_api_bad_secret(app_connection):

--- a/c2cwsgiutils/db.py
+++ b/c2cwsgiutils/db.py
@@ -72,7 +72,8 @@ def setup_session(
     return db_session, rw_engine, ro_engine
 
 
-def create_session(config: pyramid.config.Configurator, name: str, url: str, slave_url: Optional[str]=None,
+def create_session(config: Optional[pyramid.config.Configurator], name: str, url: str,
+                   slave_url: Optional[str]=None,
                    force_master: Optional[Iterable[str]]=None, force_slave: Optional[Iterable[str]]=None,
                    **engine_config: Any) \
         -> Union[sqlalchemy.orm.Session, sqlalchemy.orm.scoped_session]:

--- a/c2cwsgiutils/index.py
+++ b/c2cwsgiutils/index.py
@@ -30,7 +30,7 @@ def _index(request: pyramid.request.Request) -> pyramid.response.Response:
       <body>
     """
 
-    if auth:
+    if not auth:
         response.text += """
         <form>
           secret: <input type="text" name="secret">
@@ -108,11 +108,13 @@ def _logging(request: pyramid.request.Request, secret: str) -> str:
                 level: <input type="text" name="level" value="INFO">
                 {secret_input}
               </form></li>
+          <li><a href="{logging_url}{secret_query_sting}" target="_blank">List overrides</a>
         </ul>
         """.format(
             logging_url=logging_url,
             secret_input="" if secret is None else
             '<input type="hidden" name="secret" value="{}">'.format(html.escape(secret)),
+            secret_query_sting="" if secret is None else "?secret=" + quote_plus(secret),
         )
     else:
         return ""

--- a/c2cwsgiutils/logging_view.py
+++ b/c2cwsgiutils/logging_view.py
@@ -1,7 +1,6 @@
 import logging
-import pyramid.config
 import pyramid.request
-from typing import Mapping, Any
+from typing import Mapping, Any, Generator, Tuple
 
 from c2cwsgiutils import _utils, _auth, broadcast
 
@@ -10,6 +9,7 @@ DEPRECATED_CONFIG_KEY = 'c2c.log_view_secret'
 DEPRECATED_ENV_KEY = 'LOG_VIEW_SECRET'
 CONFIG_KEY = 'c2c.log_view_enabled'
 ENV_KEY = 'C2C_LOG_VIEW_ENABLED'
+REDIS_PREFIX = 'c2c_logging_level_'
 
 
 def install_subscriber(config: pyramid.config.Configurator) -> None:
@@ -18,23 +18,65 @@ def install_subscriber(config: pyramid.config.Configurator) -> None:
     """
     if _utils.env_or_config(config, DEPRECATED_ENV_KEY, DEPRECATED_CONFIG_KEY, False) or \
             _auth.is_enabled(config, ENV_KEY, CONFIG_KEY):
-        broadcast.subscribe('c2c_logging_level', lambda name, level: logging.getLogger(name).setLevel(level))
-
         config.add_route("c2c_logging_level", _utils.get_base_path(config) + r"/logging/level",
                          request_method="GET")
         config.add_view(_logging_change_level, route_name="c2c_logging_level", renderer="fast_json",
                         http_cache=0)
-        LOG.info("Enabled the /logging/change_level API")
+        _restore_overrides(config)
+        LOG.info("Enabled the /logging/level API")
 
 
 def _logging_change_level(request: pyramid.request.Request) -> Mapping[str, Any]:
     _auth.auth_view(request, DEPRECATED_ENV_KEY, DEPRECATED_CONFIG_KEY)
-    name = request.params['name']
-    level = request.params.get('level')
-    logger = logging.getLogger(name)
-    if level is not None:
-        LOG.critical("Logging of %s changed from %s to %s", name, logging.getLevelName(logger.level), level)
-        logger.setLevel(level)
-        broadcast.broadcast('c2c_logging_level', params={'name': name, 'level': level})
-    return {'status': 200, 'name': name, 'level': logging.getLevelName(logger.level),
-            'effective_level': logging.getLevelName(logger.getEffectiveLevel())}
+    name = request.params.get('name')
+    if name is not None:
+        level = request.params.get('level')
+        logger = logging.getLogger(name)
+        if level is not None:
+            LOG.critical("Logging of %s changed from %s to %s",
+                         name, logging.getLevelName(logger.level), level)
+            _set_level(name=name, level=level)
+            _store_override(request.registry.settings, name, level)
+        return {'status': 200, 'name': name, 'level': logging.getLevelName(logger.level),
+                'effective_level': logging.getLevelName(logger.getEffectiveLevel())}
+    else:
+        return {'status': 200, 'overrides': dict(_list_overrides(request.registry.settings))}
+
+
+@broadcast.decorator()
+def _set_level(name: str, level: str) -> None:
+    logging.getLogger(name).setLevel(level)
+
+
+def _restore_overrides(config: pyramid.config.Configurator) -> None:
+    try:
+        for name, level in _list_overrides(config.get_settings()):
+            LOG.debug("Restoring logging level override for %s: %s", name, level)
+            logging.getLogger(name).setLevel(level)
+    except ImportError:
+        pass  # don't have redis
+    except Exception:
+        # survive an error there. Logging levels is not business critical...
+        LOG.warning("Cannot restore logging levels", exc_info=True)
+
+
+def _store_override(settings: dict, name: str, level: str) -> None:
+    try:
+        import redis
+        redis_url = _utils.env_or_settings(settings, broadcast.REDIS_ENV_KEY, broadcast.REDIS_CONFIG_KEY)
+        if redis_url:
+            con = redis.StrictRedis.from_url(redis_url, socket_timeout=3, decode_responses=True)
+            con.set(REDIS_PREFIX + name, level)
+    except ImportError:
+        pass
+
+
+def _list_overrides(settings: dict) -> Generator[Tuple[str, str], None, None]:
+    import redis
+    redis_url = _utils.env_or_settings(settings, broadcast.REDIS_ENV_KEY, broadcast.REDIS_CONFIG_KEY)
+    con = redis.StrictRedis.from_url(redis_url, socket_timeout=3, decode_responses=True)
+    for key in con.scan_iter(REDIS_PREFIX + '*'):
+        level = con.get(key)
+        name = key[len(REDIS_PREFIX):]
+        if level is not None:
+            yield name, level


### PR DESCRIPTION
If redis is configured, store the logging level overrides in it. This
allows to have the logging level changes to survive periodical worker
restarts, making debugging less random.