### PR TITLE
Improve error handling

### DIFF
--- a/acceptance_tests/app/c2cwsgiutils_app/services.py
+++ b/acceptance_tests/app/c2cwsgiutils_app/services.py
@@ -1,5 +1,5 @@
 import logging
-from pyramid.httpexceptions import HTTPForbidden
+from pyramid.httpexceptions import HTTPForbidden, HTTPMovedPermanently, HTTPNoContent
 import requests
 
 from c2cwsgiutils import services
@@ -64,6 +64,10 @@ def error(request):
     code = int(request.params.get('code', '500'))
     if code == 403:
         raise HTTPForbidden('bam')
+    elif code == 301:
+        raise HTTPMovedPermanently(location="http://www.camptocamp.com/en/")
+    elif code == 204:
+        raise HTTPNoContent()
     elif request.params.get('db', '0') == 'dup':
         for _ in range(2):
             models.DBSession.add(models.Hello(value='toto'))

--- a/acceptance_tests/tests/tests/test_error.py
+++ b/acceptance_tests/tests/tests/test_error.py
@@ -26,3 +26,15 @@ def test_other(app_connection):
     error = app_connection.get_json('error', expected_status=500)
     assert error['status'] == 500
     assert error['message'] == 'boom'
+
+
+def test_redirect_exception(app_connection):
+    redirect = app_connection.get_raw('error', params={'code': 301}, expected_status=301,
+                                      allow_redirects=False)
+    assert redirect.headers['Location'] == 'http://www.camptocamp.com/en/'
+
+
+def test_no_content_exception(app_connection):
+    redirect = app_connection.get_raw('error', params={'code': 204}, expected_status=204)
+    assert 'Content-Type' not in redirect.headers, redirect.headers['Content-Type']
+    assert 'Content-Length' not in redirect.headers

--- a/c2cwsgiutils/acceptance/connection.py
+++ b/c2cwsgiutils/acceptance/connection.py
@@ -49,7 +49,7 @@ class Connection:
         with self.session.get(self.base_url + url, headers=self._merge_headers(headers, cors), **kwargs) as r:
             check_response(r, expected_status, cache_expected=cache_expected)
             self._check_cors(cors, r)
-            return None if r.status_code == 204 else r.json()
+            return _get_json(r)
 
     def get_xml(self, url: str, schema: Optional[str]=None, expected_status: int=200,
                 headers: Mapping[str, str]=None, cors: bool=True,
@@ -78,7 +78,7 @@ class Connection:
                                **kwargs) as r:
             check_response(r, expected_status, cache_expected=cache_expected)
             self._check_cors(cors, r)
-            return None if r.status_code == 204 else r.json()
+            return _get_json(r)
 
     def post_files(self, url: str, expected_status: int=200, headers: Mapping[str, str]=None,
                    cors: bool=True, cache_expected: CacheExpected=CacheExpected.NO, **kwargs: Any) -> Any:
@@ -89,7 +89,7 @@ class Connection:
                                **kwargs) as r:
             check_response(r, expected_status, cache_expected)
             self._check_cors(cors, r)
-            return None if r.status_code == 204 else r.json()
+            return _get_json(r)
 
     def post(self, url: str, expected_status: int=200, headers: Mapping[str, str]=None, cors: bool=True,
              cache_expected: CacheExpected=CacheExpected.NO, **kwargs: Any) -> Optional[str]:
@@ -110,7 +110,7 @@ class Connection:
         with self.session.put(self.base_url + url, headers=self._merge_headers(headers, cors), **kwargs) as r:
             check_response(r, expected_status, cache_expected)
             self._check_cors(cors, r)
-            return None if r.status_code == 204 else r.json()
+            return _get_json(r)
 
     def delete(self, url: str, expected_status: int=204, headers: Mapping[str, str]=None, cors: bool=True,
                cache_expected: CacheExpected=CacheExpected.NO, **kwargs: Any) -> requests.Response:
@@ -160,3 +160,11 @@ def check_response(r: requests.Response, expected_status: int=200,
     elif cache_expected == CacheExpected.YES:
         assert 'Cache-Control' in r.headers
         assert 'max-age' in r.headers['Cache-Control']
+
+
+def _get_json(r: requests.Response) -> Any:
+    if r.status_code == 204:
+        return None
+    else:
+        assert r.headers['Content-Type'] == 'application/json'
+        return r.json()


### PR DESCRIPTION
* If the beaker session cookie has an invalid signature (the secret has
  changed), return a 401 instead of a 500.
* 2xx and 3xx are now left untouched.
* Now, `raise HTTPNoContent` or `raise HTTPMovedPermanently` work
  properly.

Closes #228 