### PR TITLE
More permissive on the JSON content-types accepted

### DIFF
--- a/c2cwsgiutils/acceptance/connection.py
+++ b/c2cwsgiutils/acceptance/connection.py
@@ -166,5 +166,6 @@ def _get_json(r: requests.Response) -> Any:
     if r.status_code == 204:
         return None
     else:
-        assert r.headers['Content-Type'].split(";")[0] == 'application/json'
+        content_type = r.headers['Content-Type'].split(";")[0]
+        assert content_type == 'application/json' or content_type.endswith('+json')
         return r.json()

--- a/c2cwsgiutils/broadcast/redis.py
+++ b/c2cwsgiutils/broadcast/redis.py
@@ -90,7 +90,8 @@ class RedisBroadcaster(interface.BaseBroadcaster):
                 while len(answers) < nb_received:
                     to_wait = timeout_time - time.monotonic()
                     if to_wait <= 0.0:  # pragma: no cover
-                        LOG.warning("timeout waiting for answers on %s", answer_channel)
+                        LOG.warning("timeout waiting for %d/%d answers on %s",
+                                    len(answers), nb_received, answer_channel)
                         while len(answers) < nb_received:
                             answers.append(None)
                         return answers


### PR DESCRIPTION
Had trouble with application/geo+json.
More detailed error message when a Redis broadcast doesn't recive all
the responses.