### PR TITLE
Allow to use tags in statsd metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ To enable and configure the metrics framework, you can use:
 * STATS_VIEW (c2c.stats_view): if defined, will enable the stats view `{C2C_BASE_PATH}/stats.json`
 * STATSD_ADDRESS (c2c.statsd_address): if defined, send stats to the given statsd server
 * STATSD_PREFIX (c2c.statsd_prefix): prefix to add to every metric names
+* STATSD_USE_TAGS: If true, automatic metrics will use tags
 
 If enabled, some metrics are automatically generated:
 

--- a/acceptance_tests/app/c2cwsgiutils_app/services.py
+++ b/acceptance_tests/app/c2cwsgiutils_app/services.py
@@ -37,7 +37,7 @@ def hello_get(request):
     with timer_context(['sql', 'read_hello']):
         hello = models.DBSession.query(models.Hello).first()
     increment_counter(['test', 'counter'])
-    set_gauge(['test', 'gauge/s'], 42)
+    set_gauge(['test', 'gauge/s'], 42, tags={'value': 24, 'toto': 'tutu'})
     return {'value': hello.value}
 
 

--- a/acceptance_tests/tests/tests/test_stats.py
+++ b/acceptance_tests/tests/tests/test_stats.py
@@ -14,7 +14,7 @@ def test_ok(app_connection):
     assert stats['timers']['route/GET/hello/200']['nb'] == 1
     assert stats['timers']['sql/read_hello']['nb'] == 1
     assert stats['timers']['sql/SELECT FROM hello LIMIT ?']['nb'] == 1
-    assert stats['gauges']['test/gauge_s'] == 42
+    assert stats['gauges']['test/gauge_s/toto=tutu/value=24'] == 42
     assert stats['counters']['test/counter'] == 1
 
 
@@ -43,4 +43,4 @@ def test_redis(app_connection):
 
     stats = app_connection.get_json('c2c/stats.json', cors=False)
     print(stats)
-    assert stats['timers']['redis/PUBLISH']['nb'] >= 1
+    assert stats['timers']['redis/PUBLISH/success']['nb'] >= 1

--- a/c2cwsgiutils/redis_stats.py
+++ b/c2cwsgiutils/redis_stats.py
@@ -1,6 +1,6 @@
 import logging
 import pyramid.config
-from typing import Optional, Callable, Any  # noqa  # pylint: disable=unused-import
+from typing import Optional, Callable, Any, Dict  # noqa  # pylint: disable=unused-import
 
 from c2cwsgiutils import stats, _utils
 
@@ -9,7 +9,13 @@ ORIG = None  # type: Optional[Callable]
 
 
 def _execute_command_patch(self: Any, *args: Any, **options: Any) -> Any:
-    with stats.timer_context(['redis', args[0]]):
+    if stats.USE_TAGS:
+        key = ['redis']
+        tags = dict(cmd=args[0])  # type: Optional[Dict]
+    else:
+        key = ['redis', args[0]]
+        tags = None
+    with stats.outcome_timer_context(key, tags):
         return ORIG(self, *args, **options)  # type: ignore
 
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -32,3 +32,11 @@ def test_outcome_timer_context_failure():
 
     assert set(backend._timers.keys()) == {'toto/failure'}   # pylint: disable=W0212
     assert backend._timers['toto/failure'][0] == 1   # pylint: disable=W0212
+
+
+def test_format_tags():
+    format_tags = stats._format_tags   # pylint: disable=W0212
+    assert format_tags(None, "|", ",", "=", lambda x: x) == ""
+    assert format_tags({}, "|", ",", "=", lambda x: x) == ""
+    assert format_tags({"x": "a/b"}, "|", ",", "=", lambda x: x.replace("/", "_")) == "|x=a_b"
+    assert format_tags({"x": "a", "y/z": "b"}, "|", ",", "=", lambda x: x.replace("/", "_")) == "|x=a,y_z=b"


### PR DESCRIPTION
As documented there:
https://github.com/prometheus/statsd_exporter#dogstatsd-extensions

Automatic metrics are not using that by default to preserve backward
compatibility and not breaking all our dashboards.