### PR TITLE
More tolerant version health-check

### DIFF
--- a/c2cwsgiutils/health_check.py
+++ b/c2cwsgiutils/health_check.py
@@ -220,6 +220,7 @@ class HealthCheck(object):
         """
         def check(request: pyramid.request.Request) -> Any:
             versions = _get_all_versions()
+            versions = list(filter(lambda x: x is not None, versions))
             assert len(versions) > 0
             ref = versions[0]
             assert all(v == ref for v in versions), "Non identical versions: " + ", ". join(versions)


### PR DESCRIPTION
Some times, processes are restarted (gunicorn --max-requests). That can
lead to processes being stopped just before they can answer to the
get_version broadcast. That causes a timeout on the broadcast (10s) and
a None answer for that process.