### PR TITLE
Make upload to pypi more resilient

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -22,4 +22,16 @@ python3 ./setup.py bdist_wheel
 
 pip install twine==1.12.1 setuptools==40.4.3 wheel==0.32.1
 
-twine upload -u "${USERNAME}" -p "${PASSWORD}" dist/*.whl
+if twine upload -u "${USERNAME}" -p "${PASSWORD}" dist/*.whl
+then
+    echo "Upload to pypi successful"
+else
+    # maybe it was uploaded at the same time by another job
+    if curl --silent --fail "https://pypi.org/project/c2cwsgiutils/${VERSION}/" > /dev/null
+    then
+        echo "Already released ${VERSION} in another job"
+        exit 0
+    else
+        exit 1
+    fi
+fi


### PR DESCRIPTION
We had failures when both the master and release_2 branches were
pushed at the same time as a new tag.