### PR TITLE
Add support for the Forwarded HTTP header

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,8 +41,6 @@ dockerBuild {
             }
         }, 'mypy': {
             sh 'make mypy'
-        }, 'build full': {
-            sh 'make build_docker_full'
         }
     }
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 All the code in this library is provided under this licence:
 
-    Copyright (c) 2015-2018, Camptocamp SA
+    Copyright (c) 2015-2019, Camptocamp SA
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build_acceptance: build_docker
 	docker build --build-arg DOCKER_VERSION="$(DOCKER_VERSION)" --build-arg DOCKER_COMPOSE_VERSION="$(DOCKER_COMPOSE_VERSION)" -t $(DOCKER_BASE)_acceptance:latest acceptance_tests/tests
 
 .PHONY: build_test_app
-build_test_app: build_docker
+build_test_app: build_docker_full
 	docker build -t $(DOCKER_BASE)_test_app:latest --build-arg "GIT_HASH=$(GIT_HASH)" acceptance_tests/app
 
 .venv/timestamp: requirements.txt Makefile

--- a/README.md
+++ b/README.md
@@ -82,10 +82,15 @@ Error catching views will be put in place to return errors as JSON.
 
 A custom loader is provided to run pyramid scripts against configuration files containing environment variables:
 
-```
+```shell
 proutes c2c://production.ini  # relative path
 proutes c2c:///app/production.ini  # absolute path
 ```
+
+A filter is automatically installed to handle the HTTP headers set by common proxies and have correct values
+in the request object (`request.client_addr`, for example). This filter is equivalent to what the
+`PasteDeploy#prefix` (minus the prefix part) does, but supports newer headers as well (`Forwarded`).
+If you need to prefix your routes, you can use the `route_prefix` parameter of the `Configurator` constructor.
 
 
 ## Logging

--- a/acceptance_tests/app/Dockerfile
+++ b/acceptance_tests/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/c2cwsgiutils:latest
+FROM camptocamp/c2cwsgiutils:latest-full
 LABEL maintainer "info@camptocamp.org"
 
 # Doing things in two steps to avoid needing to re-install everything when we do a rebuild

--- a/acceptance_tests/app/production.ini
+++ b/acceptance_tests/app/production.ini
@@ -25,12 +25,6 @@ sqlalchemy_slave.max_overflow = 25
 c2c.sql_request_id = True
 c2c.requests_default_timeout = 2
 
-filter-with = proxy-prefix
-
-[filter:proxy-prefix]
-# Needed to take into account X-Forwarded-* headers
-use = egg:PasteDeploy#prefix
-
 ###
 # logging configuration
 # http://docs.pylonsproject.org/projects/pyramid/en/1.6-branch/narr/logging.html

--- a/acceptance_tests/tests/tests/test_client_info.py
+++ b/acceptance_tests/tests/tests/test_client_info.py
@@ -1,0 +1,35 @@
+import json
+
+EXPECTED = {
+    "client_addr": "1.1.1.1",
+    "host": "example.com",
+    "host_port": "443",
+    "http_version": "HTTP/1.1",
+    "path": "/api/c2c/debug/headers",
+    "path_info": "/api/c2c/debug/headers",
+    "remote_addr": "1.1.1.1",
+    "remote_host": None,
+    "scheme": "https",
+    "server_name": "0.0.0.0",
+    "server_port": 8080
+}
+
+
+def test_forwarded_openshift(app_connection):
+    response = app_connection.get_json('c2c/debug/headers', params={'secret': 'changeme'}, headers={
+        "Forwarded": "for=1.1.1.1;host=example.com;proto=https;proto-version=h2",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto-Version": "h2"
+    })
+    print("response=" + json.dumps(response, indent=4))
+    assert response['client_info'] == EXPECTED
+
+
+def test_forwarded_haproxy(app_connection):
+    response = app_connection.get_json('c2c/debug/headers', params={'secret': 'changeme'}, headers={
+        "X-Forwarded-Host": "example.com",
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-For": "1.1.1.1"
+    })
+    print("response=" + json.dumps(response, indent=4))
+    assert response['client_info'] == EXPECTED

--- a/acceptance_tests/tests/tests/test_debug.py
+++ b/acceptance_tests/tests/tests/test_debug.py
@@ -38,7 +38,7 @@ def test_headers(app_connection):
     response = app_connection.get_json('c2c/debug/headers', params={'secret': 'changeme'},
                                        headers={'X-Toto': '42'})
     print("response=" + json.dumps(response, indent=4))
-    assert response['X-Toto'] == '42'
+    assert response['headers']['X-Toto'] == '42'
 
 
 def _check_leak_there(response):

--- a/c2cwsgiutils/client_info.py
+++ b/c2cwsgiutils/client_info.py
@@ -1,0 +1,40 @@
+"""
+Small WSGI filter that interprets headers added by proxies to fix some values available in the request.
+"""
+import re
+from typing import Callable, Dict, Any
+
+
+SEP_RE = re.compile(r', *')
+
+
+class Filter:
+    def __init__(self, application: Callable):
+        self._application = application
+
+    def __call__(self, environ: Dict[str, str], start_response: Any) -> Any:
+        print(repr(environ))
+        if 'HTTP_FORWARDED' in environ:
+            forwarded = SEP_RE.split(environ.pop('HTTP_FORWARDED'))[0]
+            fields = dict(tuple(f.split('=', maxsplit=1)) for f in forwarded.split(";"))  # type: ignore
+            if 'for' in fields:
+                environ['REMOTE_ADDR'] = fields['for']
+            if 'host' in fields:
+                environ['HTTP_HOST'] = fields['host']
+            if 'proto' in fields:
+                environ['wsgi.url_scheme'] = fields['proto']
+
+        # the rest is taken from paste.deploy.config.PrefixMiddleware
+        if 'HTTP_X_FORWARDED_SERVER' in environ:
+            environ['SERVER_NAME'] = environ['HTTP_HOST'] = \
+                environ.pop('HTTP_X_FORWARDED_SERVER').split(',')[0]
+        if 'HTTP_X_FORWARDED_HOST' in environ:
+            environ['HTTP_HOST'] = environ.pop('HTTP_X_FORWARDED_HOST').split(',')[0]
+        if 'HTTP_X_FORWARDED_FOR' in environ:
+            environ['REMOTE_ADDR'] = environ.pop('HTTP_X_FORWARDED_FOR').split(',')[0]
+        if 'HTTP_X_FORWARDED_SCHEME' in environ:
+            environ['wsgi.url_scheme'] = environ.pop('HTTP_X_FORWARDED_SCHEME')
+        elif 'HTTP_X_FORWARDED_PROTO' in environ:
+            environ['wsgi.url_scheme'] = environ.pop('HTTP_X_FORWARDED_PROTO')
+
+        return self._application(environ, start_response)

--- a/c2cwsgiutils/debug.py
+++ b/c2cwsgiutils/debug.py
@@ -139,9 +139,24 @@ def _sleep(request: pyramid.request.Request) -> pyramid.response.Response:
     return request.response
 
 
-def _headers(request: pyramid.request.Request) -> Mapping[str, str]:
+def _headers(request: pyramid.request.Request) -> Mapping[str, Any]:
     auth.auth_view(request)
-    return dict(request.headers)
+    return {
+        'headers': dict(request.headers),
+        'client_info': {
+            'client_addr': request.client_addr,
+            'host': request.host,
+            'host_port': request.host_port,
+            'http_version': request.http_version,
+            'path': request.path,
+            'path_info': request.path_info,
+            'remote_addr': request.remote_addr,
+            'remote_host': request.remote_host,
+            'scheme': request.scheme,
+            'server_name': request.server_name,
+            'server_port': request.server_port
+        }
+    }
 
 
 def _error(request: pyramid.request.Request) -> Any:

--- a/c2cwsgiutils/wsgi_app.py
+++ b/c2cwsgiutils/wsgi_app.py
@@ -15,8 +15,8 @@ def create() -> Callable:  # pragma: no cover
     main_app = wsgi.create_application()
 
     # then, we can setup a few filters
-    from c2cwsgiutils import sentry, profiler
-    return sentry.filter_wsgi_app(profiler.filter_wsgi_app(main_app))
+    from c2cwsgiutils import sentry, profiler, client_info
+    return sentry.filter_wsgi_app(profiler.filter_wsgi_app(client_info.Filter(main_app)))
 
 
 application = create()  # pragma: no cover


### PR DESCRIPTION
This replaces the usage of the `PasteDeploy#prefix` filter which is
deprecated (the whole module) and doesn't support this header.

Also made the test app use the full image.