### PR TITLE
Escape environment variables for configparser

### DIFF
--- a/c2cwsgiutils/wsgi.py
+++ b/c2cwsgiutils/wsgi.py
@@ -1,13 +1,13 @@
 import logging
 import os
-from typing import Optional, Any, Dict
+from typing import Optional, Any, Mapping
 
 from pyramid.paster import get_app
 
 from c2cwsgiutils import pyramid_logging
 
 
-def _escape_variables(environ: Dict[str, str]) -> Dict[str, str]:
+def _escape_variables(environ: Mapping[str, str]) -> Mapping[str, str]:
     """
     Escape environment variables so that they can be interpreted correctly by python configparser.
     """

--- a/c2cwsgiutils/wsgi.py
+++ b/c2cwsgiutils/wsgi.py
@@ -1,10 +1,17 @@
 import logging
 import os
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 
 from pyramid.paster import get_app
 
 from c2cwsgiutils import pyramid_logging
+
+
+def _escape_variables(environ: Dict[str, str]) -> Dict[str, str]:
+    """
+    Escape environment variables so that they can be interpreted correctly by python configparser.
+    """
+    return {key: environ[key].replace('%', '%%') for key in environ}
 
 
 def create_application(configfile: Optional[str] = None) -> Any:
@@ -18,7 +25,8 @@ def create_application(configfile: Optional[str] = None) -> Any:
     configfile_ = pyramid_logging.init(configfile)
     # Load the logging config without using pyramid to be able to use environment variables in there.
     try:
-        return get_app(configfile_, 'main', options=os.environ)
+        options = _escape_variables(os.environ)
+        return get_app(configfile_, 'main', options=options)
     except Exception:
         logging.getLogger(__name__).exception("Failed starting the application")
         raise


### PR DESCRIPTION
This fixes the following issue:

```
onfigparser.InterpolationSyntaxError: Error in file /app/development.ini: '%' must be followed by '%' or '(', found: '%3Do5-947s9y'
ERROR [gunicorn.error][MainThread] Exception in worker process
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/gthread.py", line 104, in init_process
    super(ThreadWorker, self).init_process()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/wsgiapp.py", line 52, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.6/dist-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
  File "/opt/c2cwsgiutils/c2cwsgiutils/wsgi_app.py", line 22, in <module>
    application = create()  # pragma: no cover
  File "/opt/c2cwsgiutils/c2cwsgiutils/wsgi_app.py", line 15, in create
    main_app = wsgi.create_application()
  File "/opt/c2cwsgiutils/c2cwsgiutils/wsgi.py", line 21, in create_application
    return get_app(configfile_, 'main', options=os.environ)
  File "/usr/local/lib/python3.6/dist-packages/pyramid/paster.py", line 28, in get_app
    return loader.get_wsgi_app(name, options)
  File "/usr/local/lib/python3.6/dist-packages/plaster_pastedeploy/__init__.py", line 129, in get_wsgi_app
    global_conf=defaults,
  File "/usr/local/lib/python3.6/dist-packages/paste/deploy/loadwsgi.py", line 253, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/local/lib/python3.6/dist-packages/paste/deploy/loadwsgi.py", line 277, in loadobj
    global_conf=global_conf)
  File "/usr/local/lib/python3.6/dist-packages/paste/deploy/loadwsgi.py", line 302, in loadcontext
    global_conf=global_conf)
  File "/usr/local/lib/python3.6/dist-packages/paste/deploy/loadwsgi.py", line 326, in _loadconfig
    return loader.get_context(object_type, name, global_conf)
  File "/usr/local/lib/python3.6/dist-packages/paste/deploy/loadwsgi.py", line 415, in get_context
    defaults = self.parser.defaults()
  File "/usr/local/lib/python3.6/dist-packages/paste/deploy/loadwsgi.py", line 74, in defaults
    defaults[key] = self.get('DEFAULT', key) or val
  File "/usr/lib/python3.6/configparser.py", line 800, in get
    d)
  File "/usr/local/lib/python3.6/dist-packages/paste/deploy/loadwsgi.py", line 101, in before_get
    value, defaults)
  File "/usr/lib/python3.6/configparser.py", line 394, in before_get
    self._interpolate_some(parser, option, L, value, section, defaults, 1)
  File "/usr/lib/python3.6/configparser.py", line 444, in _interpolate_some
    "found: %r" % (rest,))
```
