### PR TITLE
Adapted to the new log format

### DIFF
--- a/c2cwsgiutils_check_es.py
+++ b/c2cwsgiutils_check_es.py
@@ -76,7 +76,7 @@ def _check_roundtrip() -> None:
     query = {
         "query": {
             "match_phrase": {
-                "logger_name": logger_name
+                "json.logger_name": logger_name
             }
         }
     }


### PR DESCRIPTION
Now, the fields comming from JSON logs are put inside the `json` field as an
object instead of being put at the root.