### PR TITLE
Reduce a bit memory usage

### DIFF
--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -24,6 +24,7 @@ RUN apt update && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/* && \
     pip install --no-cache-dir -r /opt/c2cwsgiutils/requirements.txt -r /opt/c2cwsgiutils/docker-requirements.txt && \
+    strip /usr/local/lib/python3.7/dist-packages/*/*.so && \
     apt remove --purge --autoremove --yes $DEV_PACKAGES binutils && \
     rm /opt/c2cwsgiutils/fake_python3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gunicorn==20.0.0
 lxml==4.4.1
 netifaces==0.10.9
 objgraph==3.4.1
-psycopg2-binary==2.8.4
+psycopg2==2.8.4
 pyramid==1.10.4
 pyramid-tm==2.3
 sentry-sdk==0.13.2


### PR DESCRIPTION
Worked on two front:

* Used the non-binary version of psycopg2. That way, we don't load
  two different versions of libc, libssl and all the companion libs
* Strip the native libs of the python dependencies.

That reduces the image size by 10MB as well.