### PR TITLE
Reduce a bit memory usage by clearing the linecache

### DIFF
--- a/c2cwsgiutils/debug/_listeners.py
+++ b/c2cwsgiutils/debug/_listeners.py
@@ -63,8 +63,15 @@ def _dump_memory_impl(limit: int, analyze_type: Optional[str]) -> Mapping[str, A
         if analyze_type == 'builtins.function':
             result[analyze_type]['modules'] = [dict(module=i[0], nb_func=i[1])
                                                for i in sorted(mod_counts.items(),
-                                                               key=lambda x: x[1])[-limit:]]
+                                                               key=lambda x: -x[1])[-limit:]]
+        elif analyze_type == 'linecache':
+            import linecache
+            cache = linecache.cache  # type: ignore
+            result[analyze_type]['biggest_objects'] = sorted([dict(filename=k, size=get_size(v))
+                                                              for k, v in cache.items()],
+                                                             key=lambda i: -i['size'])
         else:
+            biggest_objects.reverse()
             result[analyze_type]['biggest_objects'] = [dict(size=i[0], repr=repr(i[1]))
                                                        for i in biggest_objects]
     return result

--- a/c2cwsgiutils/wsgi_app.py
+++ b/c2cwsgiutils/wsgi_app.py
@@ -16,7 +16,14 @@ def create() -> Callable[[Any, Any], Any]:  # pragma: no cover
 
     # then, we can setup a few filters
     from c2cwsgiutils import sentry, profiler, client_info
-    return sentry.filter_wsgi_app(profiler.filter_wsgi_app(client_info.Filter(main_app)))
+    full_all = sentry.filter_wsgi_app(profiler.filter_wsgi_app(client_info.Filter(main_app)))
+
+    # Reduce a bit (10s of MB) the memory used by clearing the pre-cached entries for building
+    # stack traces. It will be re-built when needed with only the files needed.
+    import linecache
+    linecache.clearcache()
+
+    return full_all
 
 
 application = create()  # pragma: no cover


### PR DESCRIPTION
This stuff is used when displaying stacktraces. Every modules seems to
be pre-loaded in it. By cleaning it after the application startup, we
free a few 10s of MB and the needed modules (the ones mentioned in
stacktraces) will be loaded when needed.

Added a special analyze_type (linecache) in debug/memory to monitor that
a bit more closely.