### PR TITLE
vm and init index sizes are always 0 => remove them

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install c2cwsgiutils
 ```
 
 Or (preferred) as a base Docker image:
-[camptocamp/c2cwsgiutils:2](https://hub.docker.com/r/camptocamp/c2cwsgiutils/)
+[camptocamp/c2cwsgiutils:3](https://hub.docker.com/r/camptocamp/c2cwsgiutils/)
 
 If you need an image with a smaller foot print, use the tags prefixed with `-light`. Those are without
 gdal and without the build tools.

--- a/c2cwsgiutils_stats_db.py
+++ b/c2cwsgiutils_stats_db.py
@@ -53,14 +53,14 @@ class Reporter(object):
 
     def do_report(self, metric, value, kind, tags=None):
         LOG.info("%s.%s -> %d", kind, ".".join(metric), value)
-        if self.statsd is not None:
-            if stats.USE_TAGS and tags is not None:
-                self.statsd.gauge([kind], value, tags=tags)
-            else:
-                self.statsd.gauge([kind] + metric, value)
-        if self.prometheus is not None:
-
-            self.prometheus.add('database_table_' + kind, value, metric_labels=tags)
+        if value > 0:  # Don't export 0 values. We can always set null=0 in grafana...
+            if self.statsd is not None:
+                if stats.USE_TAGS and tags is not None:
+                    self.statsd.gauge([kind], value, tags=tags)
+                else:
+                    self.statsd.gauge([kind] + metric, value)
+            if self.prometheus is not None:
+                self.prometheus.add('database_table_' + kind, value, metric_labels=tags)
 
     def commit(self):
         if self.prometheus is not None:

--- a/c2cwsgiutils_stats_db.py
+++ b/c2cwsgiutils_stats_db.py
@@ -84,14 +84,12 @@ def do_table(session, schema, table, reporter):
 
 
 def _do_indexes(reporter, schema, session, table):
-    for index_name, size_main, size_fsm, size_vm, size_init, number_of_scans, tuples_read, tuples_fetched in \
+    for index_name, size_main, size_fsm, number_of_scans, tuples_read, tuples_fetched in \
             session.execute("""
     SELECT
          foo.indexname,
          pg_relation_size(concat(quote_ident(foo.schemaname), '.', quote_ident(foo.indexrelname)), 'main'),
          pg_relation_size(concat(quote_ident(foo.schemaname), '.', quote_ident(foo.indexrelname)), 'fsm'),
-         pg_relation_size(concat(quote_ident(foo.schemaname), '.', quote_ident(foo.indexrelname)), 'vm'),
-         pg_relation_size(concat(quote_ident(foo.schemaname), '.', quote_ident(foo.indexrelname)), 'init'),
          foo.idx_scan AS number_of_scans,
          foo.idx_tup_read AS tuples_read,
          foo.idx_tup_fetch AS tuples_fetched
@@ -107,7 +105,7 @@ def _do_indexes(reporter, schema, session, table):
          ON t.tablename = foo.ctablename AND t.schemaname=foo.schemaname
     WHERE t.schemaname=:schema AND t.tablename=:table
     """, params={'schema': schema, 'table': table}):
-        for fork, value in (('main', size_main), ('fsm', size_fsm), ('vm', size_vm), ('init', size_init)):
+        for fork, value in (('main', size_main), ('fsm', size_fsm)):
             reporter.do_report([schema, table, index_name, fork], value, kind='index_size',
                                tags=dict(schema=schema, table=table, index=index_name, fork=fork))
         for action, value in (('scan', number_of_scans), ('read', tuples_read), ('fetch', tuples_fetched)):


### PR DESCRIPTION
The database_table_index_size is the biggest metric in our prometheus.
Removing those two useless forks that are always 0 will save a lot of RAM.