### PR TITLE
Upgrade sqlalchemy to fix security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pytest==4.2.0
 pytest-cov==2.6.1
 raven==6.10.0
 requests==2.21.0
-SQLAlchemy==1.2.17
+SQLAlchemy==1.2.18
 ujson==1.35
 yamllint==1.14.0
 zope.interface==4.6.0


### PR DESCRIPTION
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| sqlalchemy                 | 1.2.17    | <=1.2.17                 | 38497    |
+==============================================================================+
| SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via |
| the order_by parameter. See: CVE-2019-7164.                                  |
+==============================================================================+
| sqlalchemy                 | 1.2.17    | ==1.2.17                 | 38496    |
+==============================================================================+
| SQLAlchemy 1.2.17 has SQL Injection when the group_by parameter can be       |
| controlled. See: CVE-2019-7548.                                              |
+==============================================================================+

See also: https://github.com/camptocamp/c2cwsgiutils/runs/936634534