### PR TITLE
[security] Bump lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ coverage==4.5.2
 flake8==3.7.5
 gunicorn==19.9.0
 junit2html==022
-lxml==4.3.1
+lxml==4.6.1
 mypy==0.670
 netifaces==0.10.9
 objgraph==3.4.0


### PR DESCRIPTION
Lxml 4.6.1 includes a fix for a vulnerability that was discovered in the    
HTML Cleaner, which allowed JavaScript to pass through.  The cleaner now     
removes more sneaky "style" content.