### PR TITLE
[security] Bump lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boltons==20.1.0
 cee-syslog-handler==0.5.0
 cornice==4.0.1
 gunicorn==20.0.4
-lxml==4.5.0
+lxml==4.6.1
 netifaces==0.10.9
 objgraph==3.4.1
 psycopg2==2.8.5


### PR DESCRIPTION
Lxml 4.6.1 includes a fix for a vulnerability that was discovered in the
HTML Cleaner, which allowed JavaScript to pass through.  The cleaner now
removes more sneaky "style" content.