### PR TITLE
Retry the query on elastic search

### DIFF
--- a/c2cwsgiutils/scripts/check_es.py
+++ b/c2cwsgiutils/scripts/check_es.py
@@ -66,7 +66,10 @@ def _check_roundtrip() -> None:
     query = {"query": {"match_phrase": {"log.logger": logger_name}}}
     start = time.monotonic()
     while time.monotonic() < start + LOG_TIMEOUT:
-        r = requests.post(SEARCH_URL, json=query, headers=SEARCH_HEADERS)
+        for _ in range(10):
+            r = requests.post(SEARCH_URL, json=query, headers=SEARCH_HEADERS)
+            if r.ok:
+                continue
         r.raise_for_status()
         json = r.json()
         found = json["hits"]["total"]


### PR DESCRIPTION
To avoid nearly every day error:
```
Traceback (most recent call last):
  File "/usr/local/bin/c2cwsgiutils-check-es", line 11, in <module>
    load_entry_point('c2cwsgiutils', 'console_scripts', 'c2cwsgiutils-check-es')()
  File "/opt/c2cwsgiutils/c2cwsgiutils/scripts/check_es.py", line 102, in main
    _check_roundtrip()
  File "/opt/c2cwsgiutils/c2cwsgiutils/scripts/check_es.py", line 70, in _check_roundtrip
    r.raise_for_status()
  File "/usr/local/lib/python3.8/dist-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 504 Server Error: Gateway Time-out for url: https://elasticsearch.logs.camptocamp.com/openshift-ch-1-gs-mutualized-print-*/_search 
```


