### PR TITLE
Fix build of release 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cornice==3.5.1
 coverage==4.5.2
 flake8==3.7.5
 gunicorn==19.9.0
+importlib-metadata==3.8.1
 junit2html==022
 lxml==4.6.2
 mypy==0.670


### PR DESCRIPTION
Not compatible with the new version of importlib-metadata (3.9.0)

Seel also : https://github.com/camptocamp/c2cwsgiutils/runs/2216686225?check_suite_focus=true