### PR TITLE
Activate sentry performance monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ A few other environment variables can be used to tune the info sent with each re
 * `SENTRY_CLIENT_IGNORE_EXCEPTIONS`: list (coma separated) of exceptions to ignore (defaults to SystemExit)
 * `SENTRY_TAG_...`: to add other custom tags
 * `SENTRY_LEVEL`: starting from what logging level to send events to Sentry (defaults to ERROR)
+* `SENTRY_TRACES_SAMPLE_RATE`: The percentage of events to send to sentry in order to compute the performance. Value between 0 and 1, default to 0.
 
 
 # Developer info

--- a/c2cwsgiutils/sentry.py
+++ b/c2cwsgiutils/sentry.py
@@ -48,9 +48,15 @@ def init(config: Optional[pyramid.config.Configurator] = None) -> None:
                 config, "SENTRY_LEVEL", "c2c.sentry_level", "ERROR"
             ).upper(),
         )
+        traces_sample_rate = float(
+            config_utils.env_or_config(
+                config, "SENTRY_TRACES_SAMPLE_RATE", "c2c.sentry_traces_sample_rate", "0.0"
+            )
+        )
         sentry_sdk.init(  # type: ignore
             dsn=sentry_url,
             integrations=[sentry_logging, PyramidIntegration(), SqlalchemyIntegration(), RedisIntegration()],
+            traces_sample_rate=traces_sample_rate,
             before_send=_create_before_send_filter(tags),
             **client_info,
         )


### PR DESCRIPTION
Use the sampling value suggested in the documentation:
https://docs.sentry.io/product/performance/getting-started/

This feature is available for sentry-sdk >= 0.11.2

Untested !

