### PR TITLE
Fix build

### DIFF
--- a/docker-requirements-full.txt
+++ b/docker-requirements-full.txt
@@ -1,2 +1,3 @@
 linesman==0.3.2
 Pillow==8.3.2
+pygraphviz==1.7


### PR DESCRIPTION
The newly release of pygraphviz (1.8) requires Python 3.8 end we use Python 3.7.