### PR TITLE
OAuth2 improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
   by `c2c://`).
 - Move back the logging configuration to `production.ini`. It will be read from `gunicorn.conf.py` at startup.
 - Remove the `development.ini` file to simplify the default application template; restore `production.ini` has the default configuration file.
-- When the `auth_type` is GitHub the `is_auth` and the `auth_type` can return different values, the is auth will just check
-  the authentication on GitHub.
+- When the `auth_type` is GitHub the `is_auth` and the `has_access` can return different values, the `is_auth` will just check
+  the authentication on GitHub succeed, `has_access` also check that the user has the desired rights.
 
 # Release 5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   by `c2c://`).
 - Move back the logging configuration to `production.ini`. It will be read from `gunicorn.conf.py` at startup.
 - Remove the `development.ini` file to simplify the default application template; restore `production.ini` has the default configuration file.
+- When the `auth_type` is GitHub the `is_auth` and the `auth_type` can return different values, the is auth will just check
+  the authentication on GitHub.
 
 # Release 5
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Using the environment variable `C2C_AUTH_GITHUB_CLIENT_SECRET` or the config key
 `c2c.auth.github.client_secret` to define the GitHub application secret (required)
 
 Using the environment variable `C2C_AUTH_GITHUB_SCOPE` or the config key `c2c.auth.github.scope` to define
-the GitHub scope (default is `repo`)
+the GitHub scope (default is `repo`), see [GitHub documentation](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)
 
 Using the environment variable `C2C_AUTH_GITHUB_SECRET` or the config key `c2c.auth.github.auth.secret` to
 define the used secret for JWD encryption (required, with a length at least of 16)
@@ -187,10 +187,11 @@ Using the environment variable `C2C_AUTH_GITHUB_REPO_URL` or the config key `c2c
 define the GitHub auth URL (default is `https://api.github.com/repo`)
 
 Using the environment variable `C2C_AUTH_GITHUB_PROXY_URL` or the config key `c2c.auth.github.auth.proxy_url` to
-define a redirect proxy between GitHub and our application to be able to share an OAuth2 application on GitHub (default is no proxy)
+define a redirect proxy between GitHub and our application to be able to share an OAuth2 application on GitHub (default is no proxy).
+Made to work with [this proxy](https://github.com/camptocamp/redirect/).
 
 Using the environment variable `C2C_USE_SESSION` or the config key `c2c.use_session` to
-define if we use a session. Currently we can use the session to store a state, used to prevent CSRF, during OAuth2 login (default is `false`)
+define if we use a session. Currently, we can use the session to store a state, used to prevent CSRF, during OAuth2 login (default is `false`)
 
 ## Pyramid
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ define the GitHub auth URL (default is `https://api.github.com/user`)
 Using the environment variable `C2C_AUTH_GITHUB_REPO_URL` or the config key `c2c.auth.github.repo_url` to
 define the GitHub auth URL (default is `https://api.github.com/repo`)
 
+Using the environment variable `C2C_AUTH_GITHUB_PROXY_URL` or the config key `c2c.auth.github.auth.proxy_url` to
+define a redirect proxy between GitHub and our application to be able to share an OAuth2 application on GitHub (default is no proxy)
+
+Using the environment variable `C2C_USE_SESSION` or the config key `c2c.use_session` to
+define if we use a session. Currently we can use the session to store a state, used to prevent CSRF, during OAuth2 login (default is `false`)
+
 ## Pyramid
 
 All the environment variables are usable in the configuration file using stuff like `%(ENV_NAME)s`.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Using the environment variable `C2C_AUTH_GITHUB_CLIENT_SECRET` or the config key
 `c2c.auth.github.client_secret` to define the GitHub application secret (required)
 
 Using the environment variable `C2C_AUTH_GITHUB_SCOPE` or the config key `c2c.auth.github.scope` to define
-the GitHub scope (default is `read:user`)
+the GitHub scope (default is `repo`)
 
 Using the environment variable `C2C_AUTH_GITHUB_SECRET` or the config key `c2c.auth.github.auth.secret` to
 define the used secret for JWD encryption (required, with a length at least of 16)

--- a/c2cwsgiutils/auth.py
+++ b/c2cwsgiutils/auth.py
@@ -31,6 +31,8 @@ GITHUB_CLIENT_SECRET_PROP = "c2c.auth.github.client_secret"  # nosec # noqa
 GITHUB_CLIENT_SECRET_ENV = "C2C_AUTH_GITHUB_CLIENT_SECRET"  # nosec # noqa
 GITHUB_SCOPE_PROP = "c2c.auth.github.scope"
 GITHUB_SCOPE_ENV = "C2C_AUTH_GITHUB_SCOPE"
+# To be able to use private repository
+GITHUB_SCOPE_DEFAULT = "repo"
 GITHUB_AUTH_COOKIE_PROP = "c2c.auth.github.auth.cookie"
 GITHUB_AUTH_COOKIE_ENV = "C2C_AUTH_GITHUB_COOKIE"
 GITHUB_AUTH_SECRET_PROP = "c2c.auth.github.auth.secret"  # nosec # noqa
@@ -205,7 +207,7 @@ def check_access(
 
     oauth = OAuth2Session(
         env_or_settings(settings, GITHUB_CLIENT_ID_ENV, GITHUB_CLIENT_ID_PROP, ""),
-        scope=[env_or_settings(settings, GITHUB_SCOPE_ENV, GITHUB_SCOPE_PROP, "read:user")],
+        scope=[env_or_settings(settings, GITHUB_SCOPE_ENV, GITHUB_SCOPE_PROP, GITHUB_SCOPE_DEFAULT)],
         redirect_uri=request.route_url("c2c_github_callback"),
         token=user["token"],
     )
@@ -231,7 +233,7 @@ def check_access(
             "pull",
         )
     repository = oauth.get(f"{repo_url}/{repo}").json()
-    if repository["permissions"][access_type] is not True:
+    if "permissions" not in repository or repository["permissions"][access_type] is not True:
         return False
     return True
 

--- a/c2cwsgiutils/auth.py
+++ b/c2cwsgiutils/auth.py
@@ -34,6 +34,10 @@ GITHUB_AUTH_COOKIE_PROP = "c2c.auth.github.auth.cookie"
 GITHUB_AUTH_COOKIE_ENV = "C2C_AUTH_GITHUB_COOKIE"
 GITHUB_AUTH_SECRET_PROP = "c2c.auth.github.auth.secret"  # nosec # noqa
 GITHUB_AUTH_SECRET_ENV = "C2C_AUTH_GITHUB_SECRET"  # nosec # noqa
+GITHUB_AUTH_PROXY_URL_PROP = "c2c.auth.github.auth.proxy_url"
+GITHUB_AUTH_PROXY_URL_ENV = "C2C_AUTH_GITHUB_PROXY_URL"
+USE_SESSION_PROP = "c2c.use_session"
+USE_SESSION_ENV = "C2C_USE_SESSION"
 
 
 LOG = logging.getLogger(__name__)

--- a/c2cwsgiutils/auth.py
+++ b/c2cwsgiutils/auth.py
@@ -193,8 +193,8 @@ def check_access(
 
     If the authentication type is not GitHub, this function is equivalent to is_auth.
 
-    `repo` is the repository to check access to.
-    `access_type` is the type of access to check.
+    `repo` is the repository to check access to (<organization>/<repository>).
+    `access_type` is the type of access to check (admin|push|pull).
     """
 
     auth, user = is_auth_user(request)

--- a/c2cwsgiutils/index.py
+++ b/c2cwsgiutils/index.py
@@ -478,7 +478,7 @@ def _github_login_callback(request: pyramid.request.Request) -> Dict[str, Any]:
         ),
     )
     raise HTTPFound(
-        location=request.session.get("came_from", _url(request, "c2c_index")),
+        location=request.params.get("came_from", _url(request, "c2c_index")),
         headers=request.response.headers,
     )
 

--- a/c2cwsgiutils/index.py
+++ b/c2cwsgiutils/index.py
@@ -24,6 +24,7 @@ from c2cwsgiutils.auth import (
     GITHUB_CLIENT_ID_PROP,
     GITHUB_CLIENT_SECRET_ENV,
     GITHUB_CLIENT_SECRET_PROP,
+    GITHUB_SCOPE_DEFAULT,
     GITHUB_SCOPE_ENV,
     GITHUB_SCOPE_PROP,
     GITHUB_TOKEN_URL_ENV,
@@ -385,7 +386,7 @@ def _github_login(request: pyramid.request.Request) -> Dict[str, Any]:
         url = callback_url
     oauth = OAuth2Session(
         env_or_settings(settings, GITHUB_CLIENT_ID_ENV, GITHUB_CLIENT_ID_PROP, ""),
-        scope=[env_or_settings(settings, GITHUB_SCOPE_ENV, GITHUB_SCOPE_PROP, "read:user")],
+        scope=[env_or_settings(settings, GITHUB_SCOPE_ENV, GITHUB_SCOPE_PROP, GITHUB_SCOPE_DEFAULT)],
         redirect_uri=url,
     )
     authorization_url, state = oauth.authorization_url(


### PR DESCRIPTION
Be able to have a redirect proxy to be able to share an OAuth2 application on GitHub

The `has_access` is extracted to be able to have some part of the application authenticated on different repository access.