### PR TITLE
Fix CVE

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,7 +28,7 @@ pyyaml = "==6.0"
 pyjwt = "==2.4.0"
 requests-oauthlib = "==1.3.1"
 setuptools = "==59.6.0"
-waitress = "==2.1.1"
+waitress = "==2.1.2"
 
 # Lock dependencies
 cee-syslog-handler = "==0.6.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "13eee3b0d637a251ed32dcca3d94dc61dffec07c87504ce4dfa2f7f433c21cd8"
+            "sha256": "e5f49b77ff0341adade96f5f51b50315dddf60cdf348921b236840a87c5818c9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -705,11 +705,11 @@
         },
         "waitress": {
             "hashes": [
-                "sha256:c549f5b2b4afd44d9d97d7cec79f3ef581e25d832827f415dc175327af674aa8",
-                "sha256:e2e60576cf14a1539da79f7b7ee1e79a71e64f366a0b47db54a15e971f57bb16"
+                "sha256:7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a",
+                "sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"
             ],
             "index": "pypi",
-            "version": "==2.1.1"
+            "version": "==2.1.2"
         },
         "webob": {
             "hashes": [


### PR DESCRIPTION
```
  +==============================================================================+
  |                                                                              |
  |                               /$$$$$$            /$$                         |
  |                              /$$__  $$          | $$                         |
  |           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
  |          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
  |         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
  |          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
  |          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
  |         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
  |                                                          /$$  | $$           |
  |                                                         |  $$$$$$/           |
  |  by pyup.io                                              \______/            |
  |                                                                              |
  +==============================================================================+
  | REPORT                                                                       |
  | checked 108 packages, using free DB (updated once a month)                   |
  +============================+===========+==========================+==========+
  | package                    | installed | affected                 | ID       |
  +============================+===========+==========================+==========+
  | waitress                   | 2.1.1     | >=2.1.0,<2.1.2           | 49257    |
  +==============================================================================+
  | Waitress 2.1.2 includes a fix for CVE-2022-31015: Waitress versions 2.1.0    |
  | and 2.1.1 may terminate early due to a thread closing a socket while the     |
  | main thread is about to call select(). This will lead to the main thread     |
  | raising an exception that is not handled and then causing the entire         |
  | application to be killed. This issue has been fixed in Waitress 2.1.2 by no  |
  | longer allowing the WSGI thread to close the socket. Instead, that is always |
  | delegated to the main thread. There is no workaround for this issue,         |
  | however, users using waitress behind a reverse proxy server are less likely  |
  | to have issues if the reverse proxy always reads the full response.          |
  | https://github.com/Pylons/waitress/security/advisories/GHSA-f5x9-8jwc-25rw   |
  +==============================================================================+
```