### PR TITLE
Address the sqlalchemy deprecations

### DIFF
--- a/acceptance_tests/app/c2cwsgiutils_app/models.py
+++ b/acceptance_tests/app/c2cwsgiutils_app/models.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
-import sqlalchemy.ext.declarative
+from sqlalchemy.orm import declarative_base
 
-Base = sqlalchemy.ext.declarative.declarative_base()
+Base = declarative_base()
 
 
 class Hello(Base):

--- a/c2cwsgiutils/sql_profiler/_impl.py
+++ b/c2cwsgiutils/sql_profiler/_impl.py
@@ -43,9 +43,10 @@ class _Repository:
                 try:
                     LOG.info("statement:\n%s", _indent(_beautify_sql(statement)))
                     LOG.info("parameters: %s", repr(parameters))
-                    output = "\n  ".join(
-                        [row[0] for row in conn.engine.execute("EXPLAIN ANALYZE " + statement, parameters)]
-                    )
+                    with conn.engine.begin() as c:
+                        output = "\n  ".join(
+                            [row[0] for row in c.execute("EXPLAIN ANALYZE " + statement, parameters)]
+                        )
                     LOG.info(output)
                 except Exception:  # nosec  # pylint: disable=broad-except
                     pass

--- a/c2cwsgiutils/sqlalchemylogger/_models.py
+++ b/c2cwsgiutils/sqlalchemylogger/_models.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Union
 
 from sqlalchemy import Column
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import func
 from sqlalchemy.types import DateTime, Integer, String
 

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -99,7 +99,8 @@ class SQLAlchemyHandler(logging.Handler):
             "schema", None
         ):
             if not self.engine.dialect.has_schema(self.engine, self.Log.__table_args__["schema"]):
-                self.engine.execute(sqlalchemy.schema.CreateSchema(self.Log.__table_args__["schema"]))
+                with self.engine.begin() as connection:
+                    connection.execute(sqlalchemy.schema.CreateSchema(self.Log.__table_args__["schema"]))
         Base.metadata.create_all(self.engine)
 
     def emit(self, record: Any) -> None:


### PR DESCRIPTION
Address sqlalchemy deprecation warnings, as found in https://github.com/openoereb/pyramid_oereb/issues/1663
There might be more deprecated code, the best would be to upgrade c2cwsgiutils to sqlalchemy 1.4.46 first, in order to get all the warnings.