### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,4 +1,4 @@
-c2cciutils==1.1.24
+c2cciutils==1.1.25
 pipfile==0.0.2
 pip>=21.1 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.5 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
    Pin cryptography@41.0.1 to cryptography@41.0.2 to fix
    ✗ Improper Certificate Validation (new) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-5777683] in cryptography@41.0.1
      introduced by c2cciutils@1.1.24 > cryptography@41.0.1 and 3 other path(s)