### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,6 +1,6 @@
 c2cciutils==1.0
 urllib3>=1.26.5 # not directly required, pinned by Snyk to avoid a vulnerability
-pip>=21.1 # not directly required, pinned by Snyk to avoid a vulnerability
+pip>=23.3 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf==3.19.6
 setuptools==59.6.0
 PyYAML==6.0


### PR DESCRIPTION
    Upgrade pip@23.0.1 to pip@23.3 to fix
    ✗ Arbitrary Command Injection (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-PIP-6036008] in pip@23.0.1
      introduced by pip@23.0.1 and 2 other path(s)