### PR TITLE
Fix doc - prometheus port var env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ command line. Usually done in the [Dockerfile](acceptance_tests/app/Dockerfile) 
 It will work in multi process mode with the limitation listed in the
 [`prometheus_client` documentation](https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn).
 
-To enable it you should provide the `C2CWSGIUTILS_PROMETHEUS_PORT` environment variable.
+To enable it you should provide the `C2C_PROMETHEUS_PORT` environment variable.
 For security reason, this port should not be exposed.
 
 We can customize it with the following environment variables:


### PR DESCRIPTION
I think it's a typo:

- [C2CWSGIUTILS_PROMETHEUS_PORT](https://github.com/search?q=repo%3Acamptocamp%2Fc2cwsgiutils%20C2CWSGIUTILS_PROMETHEUS_PORT&type=code) 
- vs
-  [C2C_PROMETHEUS_PORT](https://github.com/search?q=repo%3Acamptocamp%2Fc2cwsgiutils+C2C_PROMETHEUS_PORT&type=code)