### PR TITLE
Fix TypeError: 'NoneType' object is not iterable

### DIFF
--- a/c2cwsgiutils/prometheus.py
+++ b/c2cwsgiutils/prometheus.py
@@ -132,6 +132,9 @@ def _deserialize_collected_data(
     results: list[list[SerializedMetric]],
 ) -> Generator[prometheus_client.core.Metric, None, None]:
     for serialized_collection in results:
+        if serialized_collection is None:
+            continue
+
         for serialized_metric in serialized_collection:
             if serialized_metric is None:
                 continue

--- a/c2cwsgiutils/redis_utils.py
+++ b/c2cwsgiutils/redis_utils.py
@@ -118,7 +118,7 @@ class PubSubWorkerThread(threading.Thread):
                     last_was_ok = True
             except redis.exceptions.RedisError:
                 if last_was_ok:
-                    LOG.warning("Redis connection problem", exc_info=True)
+                    LOG.warning("Redis connection problem")
                 last_was_ok = False
                 time.sleep(0.5)
             except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/exposition.py", line 129, in prometheus_app
    status, headers, output = _bake_output(registry, accept_header, accept_encoding_header, params, disable_compression)
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/exposition.py", line 105, in _bake_output
    output = encoder(registry)
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/openmetrics/exposition.py", line 21, in generate_latest
    for metric in registry.collect():
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/registry.py", line 97, in collect
    yield from collector.collect()
  File "/usr/local/lib/python3.10/dist-packages/c2cwsgiutils/prometheus.py", line 135, in _deserialize_collected_data
    for serialized_metric in serialized_collection:
TypeError: 'NoneType' object is not iterable
----------------------------------------
Exception occurred during processing of request from ('10.10.38.202', 55654) Traceback (most recent call last):
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/exposition.py", line 129, in prometheus_app
    status, headers, output = _bake_output(registry, accept_header, accept_encoding_header, params, disable_compression)
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/exposition.py", line 105, in _bake_output
    output = encoder(registry)
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/openmetrics/exposition.py", line 21, in generate_latest
    for metric in registry.collect():
  File "/usr/local/lib/python3.10/dist-packages/prometheus_client/registry.py", line 97, in collect
    yield from collector.collect()
  File "/usr/local/lib/python3.10/dist-packages/c2cwsgiutils/prometheus.py", line 135, in _deserialize_collected_data
    for serialized_metric in serialized_collection:
TypeError: 'NoneType' object is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.10/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.10/socketserver.py", line 747, in __init__
    self.handle()
  File "/usr/lib/python3.10/wsgiref/simple_server.py", line 134, in handle
    handler.run(self.server.get_app())
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 145, in run
    self.handle_error()
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 382, in handle_error
    self.finish_response()
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 184, in finish_response
    self.write(data)
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 288, in write
    self.send_headers()
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 346, in send_headers
    self.send_preamble()
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 268, in send_preamble
    self._write(
  File "/usr/lib/python3.10/wsgiref/handlers.py", line 467, in _write
    result = self.stdout.write(data)
  File "/usr/lib/python3.10/socketserver.py", line 826, in write
    self._sock.sendall(b)
BrokenPipeError: [Errno 32] Broken pipe
----------------------------------------
HTTP/1.1 10.10.37.248:8080 GET /config/c2c/health_check? "-" "kube-probe/1.27" 200 30 2295 <9> HTTP/1.1 10.10.37.248:8080 GET /config/c2c/health_check? "-" "kube-probe/1.27" 200 30 2461 <9>
```