### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,10 +1,10 @@
-c2cciutils==1.1.32
+c2cciutils==1.1.33
 pipfile==0.0.2
 wheel==0.40.0
 pip>=21.1 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.5 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography>=41.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=42.0.2 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
 pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
    Upgrade cryptography@41.0.7 to cryptography@42.0.2 to fix
    ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6050294] in cryptography@41.0.7
      introduced by cryptography@41.0.7
    ✗ Information Exposure [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6126975] in cryptography@41.0.7
      introduced by cryptography@41.0.7
    ✗ Use of a Broken or Risky Cryptographic Algorithm (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6149518] in cryptography@41.0.7
      introduced by cryptography@41.0.7
    ✗ Uncontrolled Resource Consumption ('Resource Exhaustion') (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6157248] in cryptography@41.0.7
      introduced by cryptography@41.0.7
    ✗ NULL Pointer Dereference (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-6210214] in cryptography@41.0.7
      introduced by cryptography@41.0.7