### PR TITLE
Fix setup logging

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2024, Camptocamp SA
+Copyright (c) 2015-2025, Camptocamp SA
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/c2cwsgiutils/loader.py
+++ b/c2cwsgiutils/loader.py
@@ -3,7 +3,7 @@ from typing import Optional, cast
 
 from plaster_pastedeploy import Loader as BaseLoader
 
-from c2cwsgiutils import get_config_defaults
+from c2cwsgiutils import get_config_defaults, get_logconfig_dict
 
 _LOG = logging.getLogger(__name__)
 
@@ -19,3 +19,22 @@ class Loader(BaseLoader):  # type: ignore
     def __repr__(self) -> str:
         """Get the object representation."""
         return f'c2cwsgiutils.loader.Loader(uri="{self.uri}")'
+
+    def setup_logging(self, defaults: Optional[dict[str, str]] = None) -> None:
+        """
+        Set up logging via :func:`logging.config.dictConfig` with value returned from c2cwsgiutils.get_logconfig_dict.
+
+        Defaults are specified for the special ``__file__`` and ``here``
+        variables, similar to PasteDeploy config loading. Extra defaults can
+        optionally be specified as a dict in ``defaults``.
+
+        Arguments:
+        ---------
+        defaults: The defaults that will be used when passed to
+            :func:`logging.config.fileConfig`.
+
+        """
+        if "loggers" in self.get_sections():
+            logging.config.dictConfig(get_logconfig_dict(self.uri.path))
+        else:
+            logging.basicConfig()


### PR DESCRIPTION
To avoid:
```
  File "/usr/lib/python3.12/logging/__init__.py", line 1539, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/usr/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/venv/lib/python3.12/site-packages/sentry_sdk/integrations/logging.py", line 98, in sentry_patched_callhandlers
    return old_callhandlers(self, record)
Message: '[%s] %r'
Arguments: ('cached since 570.4s ago', {'status': 'ERROR', 'status_1': 'PENDING', 'created_at_1': datetime.datetime(2024, 12, 8, 16, 4, 28, 898425, tzinfo=datetime.timezone.utc)})
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1163, in emit
    stream.write(msg + self.terminator)
    ^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'write'
```