### PR TITLE
Fix sqlalchemylogger for use with gunicorn

### DIFF
--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -66,7 +66,7 @@ if __name__ == '__main__':
 
 ## Use with forking server (ex: `gunicorn`)
 
-snippet for configuration with gunicorn and paste:
+Snippet for configuration with `gunicorn` and `paste`:
 
 production.ini
 

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -69,6 +69,7 @@ if __name__ == '__main__':
 snippet for configuration with gunicorn and paste:
 
 production.ini
+
 ```
 [handler_sqlalchemylogger]
 class = c2cwsgiutils.sqlalchemylogger.handlers.SQLAlchemyHandler
@@ -79,6 +80,7 @@ propagate = 0
 ```
 
 gunicorn.conf.py
+
 ```
 def post_fork(server, worker):
     import logging
@@ -87,6 +89,7 @@ def post_fork(server, worker):
 ```
 
 The gunicorn must be started with this config file:
+
 ```
 gunicorn -c gunicorn.conf.py [...]
 ```

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     time.sleep(2)
 ```
 
-# Use with forking server (ex: gunicorn)
+## Use with forking server (ex: `gunicorn`)
 
 snippet for configuration with gunicorn and paste:
 

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -68,7 +68,7 @@ if __name__ == '__main__':
 
 Snippet for configuration with `gunicorn` and `paste`:
 
-production.ini
+`production.ini`:
 
 ```
 [handler_sqlalchemylogger]

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -90,6 +90,6 @@ def post_fork(server, worker):
 
 The gunicorn must be started with this config file:
 
-```
+```bash
 gunicorn -c gunicorn.conf.py [...]
 ```

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -73,7 +73,7 @@ production.ini
 ```
 [handler_sqlalchemylogger]
 class = c2cwsgiutils.sqlalchemylogger.handlers.SQLAlchemyHandler
-args = ({'url':'postgresql://','tablename':'logs','tableargs': {'schema':'logs'}, 'delay_startup': true},'healthcheck')
+args = ({'url':'postgresql://','tablename':'logs','tableargs': {'schema':'logs'}, 'delay_startup': True},'healthcheck')
 level = NOTSET
 formatter = generic
 propagate = 0

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -79,7 +79,7 @@ formatter = generic
 propagate = 0
 ```
 
-gunicorn.conf.py
+`gunicorn.conf.py`:
 
 ```python
 def post_fork(server, worker):

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -72,7 +72,7 @@ production.ini
 ```
 [handler_sqlalchemylogger]
 class = c2cwsgiutils.sqlalchemylogger.handlers.SQLAlchemyHandler
-args = ({'url':'postgresql://','tablename':'logs','tableargs': {'schema':'logs'}, 'delay_start': true},'healthcheck')
+args = ({'url':'postgresql://','tablename':'logs','tableargs': {'schema':'logs'}, 'delay_startup': true},'healthcheck')
 level = NOTSET
 formatter = generic
 propagate = 0

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -63,3 +63,30 @@ if __name__ == '__main__':
     # logs after a timeout
     time.sleep(2)
 ```
+
+# Use with forking server (ex: gunicorn)
+
+snippet for configuration with gunicorn and paste:
+
+production.ini
+```
+[handler_sqlalchemylogger]
+class = c2cwsgiutils.sqlalchemylogger.handlers.SQLAlchemyHandler
+args = ({'url':'postgresql://','tablename':'logs','tableargs': {'schema':'logs'}, 'delay_start': true},'healthcheck')
+level = NOTSET
+formatter = generic
+propagate = 0
+```
+
+gunicorn.conf.py
+```
+def post_fork(server, worker):
+    import logging
+    logger = logging.getHandlerByName('sqlalchemylogger')
+    logger.start()
+```
+
+The gunicorn must be started with this config file:
+```
+gunicorn -c gunicorn.conf.py [...]
+```

--- a/c2cwsgiutils/sqlalchemylogger/README.md
+++ b/c2cwsgiutils/sqlalchemylogger/README.md
@@ -81,7 +81,7 @@ propagate = 0
 
 gunicorn.conf.py
 
-```
+```python
 def post_fork(server, worker):
     import logging
     logger = logging.getHandlerByName('sqlalchemylogger')

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -35,6 +35,7 @@ class SQLAlchemyHandler(logging.Handler):
         """Initialize the SQLAlchemyHandler."""
         super().__init__()
 
+        self.started = False
         if sqlalchemy_url.get('delay_startup', False):
             self.sqlalchemy_url = sqlalchemy_url
             self.does_not_contain_expression = does_not_contain_expression
@@ -46,6 +47,10 @@ class SQLAlchemyHandler(logging.Handler):
         self._start(self.sqlalchemy_url, self.does_not_contain_expression, self.contains_expression)
 
     def _start(self, sqlalchemy_url, does_not_contain_expression, contains_expression):
+        if self.started:
+            # only start once
+            return
+
         # Initialize DB session
         self.engine = create_engine(sqlalchemy_url["url"])
         self.Log = create_log_class(  # pylint: disable=invalid-name
@@ -65,6 +70,7 @@ class SQLAlchemyHandler(logging.Handler):
             self.addFilter(DoesNotContainExpression(does_not_contain_expression))
         if contains_expression:
             self.addFilter(ContainsExpression(contains_expression))
+        self.started = True
 
     def _processor(self) -> None:
         _LOG.debug("%s: starting processor thread", __name__)

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -36,7 +36,7 @@ class SQLAlchemyHandler(logging.Handler):
         """Initialize the SQLAlchemyHandler."""
         super().__init__()
 
-        if delay_startup:
+        if sqlalchemy_url.get('delay_startup', False):
             self.sqlalchemy_url = sqlalchemy_url
             self.does_not_contain_expression = does_not_contain_expression
             self.contains_expression = contains_expression

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -31,7 +31,7 @@ class SQLAlchemyHandler(logging.Handler):
         sqlalchemy_url: dict[str, str],
         does_not_contain_expression: str = "",
         contains_expression: str = "",
-        delay_startup = False,
+        delay_startup=False,
     ) -> None:
         """Initialize the SQLAlchemyHandler."""
         super().__init__()
@@ -45,7 +45,7 @@ class SQLAlchemyHandler(logging.Handler):
 
     def start(self):
         self._start(self.sqlalchemy_url, self.does_not_contain_expression, self.contains_expression)
-        
+
     def _start(self, sqlalchemy_url, does_not_contain_expression, contains_expression):
         # Initialize DB session
         self.engine = create_engine(sqlalchemy_url["url"])

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -31,7 +31,6 @@ class SQLAlchemyHandler(logging.Handler):
         sqlalchemy_url: dict[str, str],
         does_not_contain_expression: str = "",
         contains_expression: str = "",
-        delay_startup=False,
     ) -> None:
         """Initialize the SQLAlchemyHandler."""
         super().__init__()

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -31,9 +31,22 @@ class SQLAlchemyHandler(logging.Handler):
         sqlalchemy_url: dict[str, str],
         does_not_contain_expression: str = "",
         contains_expression: str = "",
+        delay_startup = False,
     ) -> None:
         """Initialize the SQLAlchemyHandler."""
         super().__init__()
+
+        if delay_startup:
+            self.sqlalchemy_url = sqlalchemy_url
+            self.does_not_contain_expression = does_not_contain_expression
+            self.contains_expression = contains_expression
+        else:
+            self._start(sqlalchemy_url, does_not_contain_expression, contains_expression)
+
+    def start(self):
+        self._start(self.sqlalchemy_url, self.does_not_contain_expression, self.contains_expression)
+        
+    def _start(self, sqlalchemy_url, does_not_contain_expression, contains_expression):
         # Initialize DB session
         self.engine = create_engine(sqlalchemy_url["url"])
         self.Log = create_log_class(  # pylint: disable=invalid-name

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -36,7 +36,7 @@ class SQLAlchemyHandler(logging.Handler):
         super().__init__()
 
         self.started = False
-        if sqlalchemy_url.get('delay_startup', False):
+        if sqlalchemy_url.get("delay_startup", False):
             self.sqlalchemy_url = sqlalchemy_url
             self.does_not_contain_expression = does_not_contain_expression
             self.contains_expression = contains_expression

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -43,10 +43,16 @@ class SQLAlchemyHandler(logging.Handler):
         else:
             self._start(sqlalchemy_url, does_not_contain_expression, contains_expression)
 
-    def start(self):
+    def start(self) -> None:
+        """Force startup of logger in case of delayed startup"""
         self._start(self.sqlalchemy_url, self.does_not_contain_expression, self.contains_expression)
 
-    def _start(self, sqlalchemy_url, does_not_contain_expression, contains_expression):
+    def _start(
+        self,
+        sqlalchemy_url: dict[str, str],
+        does_not_contain_expression: str,
+        contains_expression: str,
+    ) -> None:
         if self.started:
             # only start once
             return

--- a/c2cwsgiutils/sqlalchemylogger/handlers.py
+++ b/c2cwsgiutils/sqlalchemylogger/handlers.py
@@ -44,7 +44,7 @@ class SQLAlchemyHandler(logging.Handler):
             self._start(sqlalchemy_url, does_not_contain_expression, contains_expression)
 
     def start(self) -> None:
-        """Force startup of logger in case of delayed startup"""
+        """Force startup of logger in case of delayed startup."""
         self._start(self.sqlalchemy_url, self.does_not_contain_expression, self.contains_expression)
 
     def _start(


### PR DESCRIPTION
The forking server gunicorn will start the bachground thread of the sqlalchemylogger in the main process by default
synchronisation will not work correctly.

This patch enables delaying the logger startup to move it to a post_fork hook if needed