### PR TITLE
Make the Redis PubSub retry delay and get_message timeout configurable

### DIFF
--- a/c2cwsgiutils/redis_utils.py
+++ b/c2cwsgiutils/redis_utils.py
@@ -130,9 +130,7 @@ class PubSubWorkerThread(threading.Thread):
         last_was_ok = True
         while pubsub.subscribed:
             try:
-                pubsub.get_message(
-                    ignore_subscribe_messages=True, timeout=self._get_message_timeout
-                )
+                pubsub.get_message(ignore_subscribe_messages=True, timeout=self._get_message_timeout)
                 if not last_was_ok:
                     LOG.debug("Redis is back")
                     last_was_ok = True

--- a/c2cwsgiutils/redis_utils.py
+++ b/c2cwsgiutils/redis_utils.py
@@ -17,12 +17,16 @@ REDIS_OPTIONS_KEY = "C2C_REDIS_OPTIONS"
 REDIS_SENTINELS_KEY = "C2C_REDIS_SENTINELS"
 REDIS_SERVICENAME_KEY = "C2C_REDIS_SERVICENAME"
 REDIS_DB_KEY = "C2C_REDIS_DB"
+_REDIS_PUBSUB_RETRY_DELAY_KEY = "C2C_REDIS_PUBSUB_RETRY_DELAY"
+_REDIS_PUBSUB_GET_MESSAGE_TIMEOUT_KEY = "C2C_REDIS_PUBSUB_GET_MESSAGE_TIMEOUT"
 
 REDIS_URL_KEY_PROP = "c2c.redis_url"
 REDIS_OPTIONS_KEY_PROP = "c2c.redis_options"
 REDIS_SENTINELS_KEY_PROP = "c2c.redis_sentinels"
 REDIS_SERVICENAME_KEY_PROP = "c2c.redis_servicename"
 REDIS_DB_KEY_PROP = "c2c.redis_db"
+_REDIS_PUBSUB_RETRY_DELAY_KEY_PROP = "c2c.redis_pubsub_retry_delay"
+_REDIS_PUBSUB_GET_MESSAGE_TIMEOUT_KEY_PROP = "c2c.redis_pubsub_get_message_timeout"
 
 _master: Optional["redis.client.Redis[str]"] = None
 _slave: Optional["redis.client.Redis[str]"] = None
@@ -93,10 +97,30 @@ def _init(settings: Optional[Mapping[str, Any]]) -> None:
 class PubSubWorkerThread(threading.Thread):
     """A clone of redis.client.PubSubWorkerThread that doesn't die when the connections are broken."""
 
-    def __init__(self, pubsub: redis.client.PubSub, name: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        pubsub: redis.client.PubSub,
+        name: str | None = None,
+        settings: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize the PubSubWorkerThread."""
         super().__init__(name=name, daemon=True)
         self.pubsub = pubsub
         self._running = False
+        self._retry_delay = c2cwsgiutils.config_utils.env_or_settings(
+            settings,
+            _REDIS_PUBSUB_RETRY_DELAY_KEY,
+            _REDIS_PUBSUB_RETRY_DELAY_KEY_PROP,
+            0.5,
+            float,
+        )
+        self._get_message_timeout = c2cwsgiutils.config_utils.env_or_settings(
+            settings,
+            _REDIS_PUBSUB_GET_MESSAGE_TIMEOUT_KEY,
+            _REDIS_PUBSUB_GET_MESSAGE_TIMEOUT_KEY_PROP,
+            1.0,
+            float,
+        )
 
     def run(self) -> None:
         if self._running:
@@ -106,15 +130,17 @@ class PubSubWorkerThread(threading.Thread):
         last_was_ok = True
         while pubsub.subscribed:
             try:
-                pubsub.get_message(ignore_subscribe_messages=True, timeout=1)
+                pubsub.get_message(
+                    ignore_subscribe_messages=True, timeout=self._get_message_timeout
+                )
                 if not last_was_ok:
-                    LOG.info("Redis is back")
+                    LOG.debug("Redis is back")
                     last_was_ok = True
             except redis.exceptions.RedisError:
                 if last_was_ok:
-                    LOG.warning("Redis connection problem", exc_info=True)
+                    LOG.debug("Redis connection problem")
                 last_was_ok = False
-                time.sleep(0.5)
+                time.sleep(self._retry_delay)
             except Exception:  # pylint: disable=broad-except
                 LOG.warning("Unexpected error", exc_info=True)
         LOG.info("Redis subscription worker stopped")


### PR DESCRIPTION
The retry delay and get_message timeout in the PubSub worker thread are now configurable through C2C_REDIS_PUBSUB_RETRY_DELAY and C2C_REDIS_PUBSUB_GET_MESSAGE_TIMEOUT. The connection problem messages are now logged in debug instead of warning to avoid noise.

<!-- pull request links -->
See JIRA issue: [GSGEOC-452](https://camptocamp.atlassian.net/browse/GSGEOC-452).

[GSGEOC-452]: https://camptocamp.atlassian.net/browse/GSGEOC-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ